### PR TITLE
fix(probe): use protocol-aware default port for endpoint probing

### DIFF
--- a/src/probe.ts
+++ b/src/probe.ts
@@ -7,16 +7,22 @@ export type ProbeResult = { ok: boolean; ms: number; error?: string }
  * Opens a TCP connection to the host and port parsed from `endpoint` to verify
  * reachability before the OTel SDK initialises. Resolves within 5 seconds.
  */
-export function probeEndpoint(endpoint: string): Promise<ProbeResult> {
-  let host: string
-  let port: number
+export function parseEndpoint(endpoint: string): { host: string; port: number } | null {
   try {
     const url = new URL(endpoint)
-    host = url.hostname
-    port = parseInt(url.port || "4317", 10)
+    const defaultPort = url.protocol === "http:" ? 80 : url.protocol === "https:" ? 443 : 4317
+    return { host: url.hostname, port: url.port ? parseInt(url.port, 10) : defaultPort }
   } catch {
+    return null
+  }
+}
+
+export function probeEndpoint(endpoint: string): Promise<ProbeResult> {
+  const parsed = parseEndpoint(endpoint)
+  if (!parsed) {
     return Promise.resolve({ ok: false, ms: 0, error: `invalid endpoint URL: ${endpoint}` })
   }
+  const { host, port } = parsed
   return new Promise((resolve) => {
     const start = Date.now()
     const socket = net.createConnection({ host, port }, () => {

--- a/tests/probe.test.ts
+++ b/tests/probe.test.ts
@@ -1,5 +1,27 @@
 import { describe, test, expect } from "bun:test"
-import { probeEndpoint } from "../src/probe.ts"
+import { probeEndpoint, parseEndpoint } from "../src/probe.ts"
+
+describe("parseEndpoint", () => {
+  test("uses port 80 for http:// URLs without explicit port", () => {
+    expect(parseEndpoint("http://api.honeycomb.io")).toEqual({ host: "api.honeycomb.io", port: 80 })
+  })
+
+  test("uses port 443 for https:// URLs without explicit port", () => {
+    expect(parseEndpoint("https://api.honeycomb.io")).toEqual({ host: "api.honeycomb.io", port: 443 })
+  })
+
+  test("uses explicit port when provided", () => {
+    expect(parseEndpoint("http://localhost:4317")).toEqual({ host: "localhost", port: 4317 })
+  })
+
+  test("defaults to 4317 for unknown protocols without explicit port", () => {
+    expect(parseEndpoint("grpc://api.honeycomb.io")).toEqual({ host: "api.honeycomb.io", port: 4317 })
+  })
+
+  test("returns null for invalid URLs", () => {
+    expect(parseEndpoint("not a url")).toBeNull()
+  })
+})
 
 describe("probeEndpoint", () => {
   test("returns error for malformed URL (no scheme)", async () => {


### PR DESCRIPTION
fix #3 

Previously the probe always fell back to port 4317 when no explicit port was provided, even for http:// (80) and https:// (443) URLs. This caused the probe to check a different port than the OTel SDK would actually connect to. Extract parseEndpoint to make the parsing logic independently testable.

See also https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp

> That also means, if the port is empty or not given, TCP port 80 is the default for the http scheme and TCP port 443 is the default for the https scheme,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added endpoint URL parsing capability with automatic port assignment based on protocol scheme: HTTP defaults to port 80, HTTPS to port 443, and other schemes to port 4317.

* **Refactor**
  * Improved endpoint validation logic with enhanced error handling and clearer feedback for invalid or malformed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->