### PR TITLE
fix: Normalize token and cost units for Claude compatibility

### DIFF
--- a/src/otel.ts
+++ b/src/otel.ts
@@ -118,11 +118,11 @@ export function createInstruments(prefix: string): Instruments {
       description: "Number of completed assistant messages per session",
     }),
     sessionTokenGauge: meter.createHistogram(`${prefix}session.token.total`, {
-      unit: "{token}",
+      unit: "tokens",
       description: "Total tokens consumed per session, recorded as a histogram on session idle",
     }),
     sessionCostGauge: meter.createHistogram(`${prefix}session.cost.total`, {
-      unit: "[USD]",
+      unit: "USD",
       description: "Total cost per session in USD, recorded as a histogram on session idle",
     }),
     modelUsageCounter: meter.createCounter(`${prefix}model.usage`, {

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -86,11 +86,11 @@ export function createInstruments(prefix: string): Instruments {
       description: "Count of opencode sessions started",
     }),
     tokenCounter: meter.createCounter(`${prefix}token.usage`, {
-      unit: "{token}",
+      unit: "tokens",
       description: "Number of tokens used",
     }),
     costCounter: meter.createCounter(`${prefix}cost.usage`, {
-      unit: "[USD]",
+      unit: "USD",
       description: "Cost of the opencode session in USD",
     }),
     linesCounter: meter.createCounter(`${prefix}lines_of_code.count`, {


### PR DESCRIPTION
## Why

This PR fixes #13 

### Root cause
The mismatch comes from instrument unit strings used for these metrics:
- `[USD]` on cost metrics
- `{token}` on token metrics

In OTLP->Prometheus translation, bracket/annotation-style units can lead to:
- `[USD]` can produce a double underscore after [Prometheus exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter) translation: with `UnderscoreEscapingWithSuffixes`, `[` and `]` are converted to `_`, so the unit part becomes `_USD_`; then the counter suffix `_total` is appended, resulting in `..._USD__total`.
- dropped token unit suffix (missing `tokens` in the final name)

### What changed
In `src/otel.ts`, units were normalized to plain values:
- token.usage: `{token}` -> `tokens`
- cost.usage: `[USD]` -> `USD`

I also applied the same normalization to related session histograms for consistency:
- session.token.total: `{token}` -> `tokens`
- session.cost.total: `[USD]` -> `USD`

No instrument names, attributes, event handling, or aggregation logic were changed.

### Expected outcome
Prometheus series names align with Claude Code conventions, including:
- `claude_code_token_usage_tokens_total`
- `claude_code_cost_usage_USD_total`

and consistent session histogram naming without the extra underscore artifact.

### Validation
- `bun run typecheck`
- `bun test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unit labels for metrics tracking tokens and costs to display in standard formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->