### PR TITLE
docs: fix Datadog example -- correct endpoint, add required header and temporality env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,17 @@ export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.tota
 
 ```bash
 export OPENCODE_ENABLE_TELEMETRY=1
-export OPENCODE_OTLP_ENDPOINT=https://api.datadoghq.com
+export OPENCODE_OTLP_ENDPOINT=https://otlp.datadoghq.com
 export OPENCODE_OTLP_PROTOCOL=http/protobuf
+export OPENCODE_OTLP_HEADERS="dd-api-key=YOUR_DATADOG_API_KEY"
+
+# Required — Datadog's OTLP intake only accepts delta temporality
+export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
 ```
+
+> **Note:** The endpoint is `otlp.datadoghq.com` (not `api.datadoghq.com`).
+> Use `otlp.datadoghq.eu` for EU, `otlp.us3.datadoghq.com` for US3, etc.
+> See [Datadog OTLP docs](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/) for all regions.
 
 ### Honeycomb example
 


### PR DESCRIPTION
## Description

**Impact:** Anyone following the current Datadog example in the README will get zero metrics -- the endpoint is wrong, the auth header is missing, and the required temporality setting is undocumented.

Three issues fixed:

1. **Wrong endpoint** -- `api.datadoghq.com` is the REST API, not the OTLP intake. The correct endpoint is `otlp.datadoghq.com` ([Datadog OTLP docs](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/)).
2. **Missing auth header** -- Datadog's OTLP intake requires `dd-api-key` in the request headers.
3. **Missing temporality env var** -- Datadog requires delta aggregation temporality for counters and histograms. Without `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`, the OTel SDK defaults to cumulative and Datadog silently drops the data ([Datadog delta temporality guide](https://docs.datadoghq.com/opentelemetry/guide/otlp_delta_temporality/), [OTel spec](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/)). The JS SDK's OTLP exporter [already reads this env var](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts) -- no code change needed.

Also adds region guidance (EU, US3, etc.) with a link to the official docs.

## Type of change

- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [x] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

Discovered while integrating this plugin with Datadog's direct OTLP intake at `otlp.datadoghq.com`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed Datadog configuration examples with updated OTLP endpoint details and correct hostname information
  * Added environment variable configuration examples for proper API key setup
  * Enhanced documentation with regional endpoint variants to support global deployments across different geographic regions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->