### PR TITLE
fix: respect OPENCODE_OTLP_METRICS_TEMPORALITY for Datadog delta temporality

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ export OPENCODE_OTLP_METRICS_TEMPORALITY=delta
 
 > **Note:** The endpoint is `otlp.datadoghq.com` (not `api.datadoghq.com`).
 > Use `otlp.datadoghq.eu` for EU, `otlp.us3.datadoghq.com` for US3, etc.
-> See [Datadog OTLP docs](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/) for all regions.
+> See [Datadog OTLP docs](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest_in_the_agent/) for all regions.
 
 ### Honeycomb example
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ All configuration is via environment variables. Set them in your shell profile (
 | `OPENCODE_DISABLE_METRICS` | _(unset)_ | Comma-separated list of metric name suffixes to disable (e.g. `cache.count,session.duration`) |
 | `OPENCODE_OTLP_HEADERS` | _(unset)_ | Comma-separated `key=value` headers added to all OTLP exports. **Keep out of version control — may contain sensitive auth tokens.** |
 | `OPENCODE_RESOURCE_ATTRIBUTES` | _(unset)_ | Comma-separated `key=value` pairs merged into the OTel resource. Example: `service.version=1.2.3,deployment.environment=production` |
+| `OPENCODE_OTLP_METRICS_TEMPORALITY` | _(unset)_ | Metrics aggregation temporality: `delta`, `cumulative`, or `lowmemory`. Required for Datadog (`delta`). Copied to `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. |
 
 ### Quick start
 
@@ -150,9 +151,17 @@ export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.tota
 
 ```bash
 export OPENCODE_ENABLE_TELEMETRY=1
-export OPENCODE_OTLP_ENDPOINT=https://api.datadoghq.com
+export OPENCODE_OTLP_ENDPOINT=https://otlp.datadoghq.com
 export OPENCODE_OTLP_PROTOCOL=http/protobuf
+export OPENCODE_OTLP_HEADERS="dd-api-key=YOUR_DATADOG_API_KEY"
+
+# Required — Datadog's OTLP intake only accepts delta temporality
+export OPENCODE_OTLP_METRICS_TEMPORALITY=delta
 ```
+
+> **Note:** The endpoint is `otlp.datadoghq.com` (not `api.datadoghq.com`).
+> Use `otlp.datadoghq.eu` for EU, `otlp.us3.datadoghq.com` for US3, etc.
+> See [Datadog OTLP docs](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/) for all regions.
 
 ### Honeycomb example
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,17 +25,20 @@ export function parseEnvInt(key: string, fallback: number): number {
 
 /**
  * Reads all `OPENCODE_*` environment variables and returns the resolved plugin config.
- * Copies `OPENCODE_OTLP_HEADERS` → `OTEL_EXPORTER_OTLP_HEADERS` and
- * `OPENCODE_RESOURCE_ATTRIBUTES` → `OTEL_RESOURCE_ATTRIBUTES` so the OTel SDK
- * picks them up automatically when initialised.
+ * Copies `OPENCODE_OTLP_HEADERS` → `OTEL_EXPORTER_OTLP_HEADERS`,
+ * `OPENCODE_RESOURCE_ATTRIBUTES` → `OTEL_RESOURCE_ATTRIBUTES`, and
+ * `OPENCODE_OTLP_METRICS_TEMPORALITY` → `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
+ * so the OTel SDK picks them up automatically when initialised.
  */
 export function loadConfig(): PluginConfig {
   const otlpHeaders = process.env["OPENCODE_OTLP_HEADERS"]
   const resourceAttributes = process.env["OPENCODE_RESOURCE_ATTRIBUTES"]
+  const metricsTemporality = process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
   const protocol = process.env["OPENCODE_OTLP_PROTOCOL"]
 
   if (otlpHeaders) process.env["OTEL_EXPORTER_OTLP_HEADERS"] = otlpHeaders
   if (resourceAttributes) process.env["OTEL_RESOURCE_ATTRIBUTES"] = resourceAttributes
+  if (metricsTemporality) process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = metricsTemporality
 
   const disabledMetrics = new Set(
     (process.env["OPENCODE_DISABLE_METRICS"] ?? "")

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,10 @@
 import { LEVELS, type Level } from "./types.ts"
 
+/** Accepted values for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. */
+export type MetricsTemporality = "cumulative" | "delta" | "lowmemory"
+
+const VALID_TEMPORALITIES: ReadonlySet<MetricsTemporality> = new Set<MetricsTemporality>(["cumulative", "delta", "lowmemory"])
+
 /** Configuration values resolved from `OPENCODE_*` environment variables. */
 export type PluginConfig = {
   enabled: boolean
@@ -10,6 +15,7 @@ export type PluginConfig = {
   metricPrefix: string
   otlpHeaders: string | undefined
   resourceAttributes: string | undefined
+  metricsTemporality: MetricsTemporality | undefined
   disabledMetrics: Set<string>
   disabledTraces: Set<string>
 }
@@ -33,12 +39,25 @@ export function parseEnvInt(key: string, fallback: number): number {
 export function loadConfig(): PluginConfig {
   const otlpHeaders = process.env["OPENCODE_OTLP_HEADERS"]
   const resourceAttributes = process.env["OPENCODE_RESOURCE_ATTRIBUTES"]
-  const metricsTemporality = process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
+  const rawTemporality = process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
   const protocol = process.env["OPENCODE_OTLP_PROTOCOL"]
+
+  let metricsTemporality: MetricsTemporality | undefined
+  if (rawTemporality) {
+    const normalized = rawTemporality.toLowerCase()
+    if (VALID_TEMPORALITIES.has(normalized as MetricsTemporality)) {
+      metricsTemporality = normalized as MetricsTemporality
+      process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = normalized
+    } else {
+      console.warn(
+        `[opencode-plugin-otel] Invalid OPENCODE_OTLP_METRICS_TEMPORALITY="${rawTemporality}". ` +
+          `Expected one of: cumulative, delta, lowmemory. Value ignored.`,
+      )
+    }
+  }
 
   if (otlpHeaders) process.env["OTEL_EXPORTER_OTLP_HEADERS"] = otlpHeaders
   if (resourceAttributes) process.env["OTEL_RESOURCE_ATTRIBUTES"] = resourceAttributes
-  if (metricsTemporality) process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = metricsTemporality
 
   const disabledMetrics = new Set(
     (process.env["OPENCODE_DISABLE_METRICS"] ?? "")
@@ -63,6 +82,7 @@ export function loadConfig(): PluginConfig {
     metricPrefix: process.env["OPENCODE_METRIC_PREFIX"] ?? "opencode.",
     otlpHeaders,
     resourceAttributes,
+    metricsTemporality,
     disabledMetrics,
     disabledTraces,
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -49,10 +49,12 @@ describe("loadConfig", () => {
     "OPENCODE_OTLP_LOGS_INTERVAL",
     "OPENCODE_OTLP_HEADERS",
     "OPENCODE_RESOURCE_ATTRIBUTES",
+    "OPENCODE_OTLP_METRICS_TEMPORALITY",
     "OPENCODE_DISABLE_METRICS",
     "OPENCODE_DISABLE_TRACES",
     "OTEL_EXPORTER_OTLP_HEADERS",
     "OTEL_RESOURCE_ATTRIBUTES",
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
   ]
   beforeEach(() => vars.forEach((k) => delete process.env[k]))
   afterEach(() => vars.forEach((k) => delete process.env[k]))
@@ -118,6 +120,18 @@ describe("loadConfig", () => {
     delete process.env["OPENCODE_OTLP_HEADERS"]
     loadConfig()
     expect(process.env["OTEL_EXPORTER_OTLP_HEADERS"]).toBeUndefined()
+  })
+
+  test("copies OPENCODE_OTLP_METRICS_TEMPORALITY to OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", () => {
+    process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"] = "delta"
+    loadConfig()
+    expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBe("delta")
+  })
+
+  test("does not set OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE when OPENCODE_OTLP_METRICS_TEMPORALITY is unset", () => {
+    delete process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
+    loadConfig()
+    expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBeUndefined()
   })
 
   test("does not overwrite pre-existing OTEL_* vars when OPENCODE_* vars are unset", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -124,14 +124,39 @@ describe("loadConfig", () => {
 
   test("copies OPENCODE_OTLP_METRICS_TEMPORALITY to OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", () => {
     process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"] = "delta"
-    loadConfig()
+    const cfg = loadConfig()
     expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBe("delta")
+    expect(cfg.metricsTemporality).toBe("delta")
   })
 
   test("does not set OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE when OPENCODE_OTLP_METRICS_TEMPORALITY is unset", () => {
     delete process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
-    loadConfig()
+    const cfg = loadConfig()
     expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBeUndefined()
+    expect(cfg.metricsTemporality).toBeUndefined()
+  })
+
+  test("normalizes OPENCODE_OTLP_METRICS_TEMPORALITY to lowercase", () => {
+    process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"] = "Delta"
+    const cfg = loadConfig()
+    expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBe("delta")
+    expect(cfg.metricsTemporality).toBe("delta")
+  })
+
+  test("ignores invalid OPENCODE_OTLP_METRICS_TEMPORALITY and warns", () => {
+    const warnings: string[] = []
+    const origWarn = console.warn
+    console.warn = (...args: unknown[]) => warnings.push(String(args[0]))
+    try {
+      process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"] = "bogus"
+      const cfg = loadConfig()
+      expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBeUndefined()
+      expect(cfg.metricsTemporality).toBeUndefined()
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain("bogus")
+    } finally {
+      console.warn = origWarn
+    }
   })
 
   test("does not overwrite pre-existing OTEL_* vars when OPENCODE_* vars are unset", () => {


### PR DESCRIPTION
## Description

Adds support for `OPENCODE_OTLP_METRICS_TEMPORALITY` env var and fixes the Datadog example in the README.

**Problem:** Datadog requires delta aggregation temporality for OTLP metrics, but configuring this requires setting the raw OpenTelemetry env var `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. This breaks the plugin's convention where all user-facing config uses the `OPENCODE_*` prefix (mapped internally to `OTEL_*` vars).

**Fix:** `loadConfig()` in `config.ts` now copies `OPENCODE_OTLP_METRICS_TEMPORALITY` to `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, following the same pattern used by every other env var in the plugin. The value is normalized to lowercase and validated against the allowed set (`cumulative`, `delta`, `lowmemory`) -- invalid values produce a warning and are ignored, preventing the silent-fallback-to-cumulative footgun. The resolved value is also exposed on `PluginConfig` for introspection/logging. The README Datadog example is updated with the correct endpoint (`otlp.datadoghq.com`), required `dd-api-key` header, and the new temporality env var.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

Datadog's OTLP ingest requires delta temporality ([docs](https://docs.datadoghq.com/opentelemetry/guide/otlp_delta_temporality/)). The JS SDK's `OTLPHttpMetricExporter` reads `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` automatically ([source](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts)), so no code changes to `otel.ts` are needed -- the config copy is sufficient.

## Additional context

Changes:
- **`src/config.ts`** -- added `OPENCODE_OTLP_METRICS_TEMPORALITY` to `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` copy in `loadConfig()`, with lowercase normalization and validation; added `metricsTemporality` field to `PluginConfig`
- **`tests/config.test.ts`** -- 4 tests: valid copy, unset no-op, case normalization, invalid value warning
- **`README.md`** -- fixed Datadog example (endpoint, header, temporality), added env var to table, added region guidance

---

<sub>Drafted with OpenCode (claude-opus-4.6) -- your review, your call.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring metrics temporality preference (cumulative, delta, or low-memory modes) via a new environment variable.

* **Documentation**
  * Updated Datadog integration setup with correct OTLP endpoint and required authentication configuration.
  * Documented the new metrics temporality configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->