### PR TITLE
fix: bundle plugin to JS for server mode compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
     "eslint-plugin-jsdoc": "^50.6.11"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./dist/index.js",
+    "./server": "./dist/index.js"
   },
   "files": [
-    "src/"
+    "dist/"
   ],
   "homepage": "https://github.com/DEVtheOPS/opencode-plugin-otel#readme",
   "keywords": [
@@ -44,8 +45,8 @@
     "observability"
   ],
   "license": "MPL-2.0",
-  "main": "src/index.ts",
-  "module": "src/index.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
   "name": "@devtheops/opencode-plugin-otel",
   "oc-plugin": [
     "server"
@@ -58,9 +59,11 @@
     "url": "https://github.com/DEVtheOPS/opencode-plugin-otel.git"
   },
   "scripts": {
+    "build": "bun build src/index.ts --outdir=./dist --target=node",
     "check:jsdoc-coverage": "bun scripts/check-jsdoc-coverage.mjs",
     "lint": "bun --bun eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
   },
   "type": "module",
   "version": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,14 @@
     "eslint-plugin-jsdoc": "^50.6.11"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./server": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "files": [
     "dist/"
@@ -47,6 +53,7 @@
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "name": "@devtheops/opencode-plugin-otel",
   "oc-plugin": [
     "server"
@@ -59,7 +66,7 @@
     "url": "https://github.com/DEVtheOPS/opencode-plugin-otel.git"
   },
   "scripts": {
-    "build": "bun build src/index.ts --outdir=./dist --target=node",
+    "build": "bun build src/index.ts --outdir=./dist --target=node && tsc -p tsconfig.build.json",
     "check:jsdoc-coverage": "bun scripts/check-jsdoc-coverage.mjs",
     "lint": "bun --bun eslint .",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "check:jsdoc-coverage": "bun scripts/check-jsdoc-coverage.mjs",
     "lint": "bun --bun eslint .",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "bun run build"
+    "prepack": "bun run build"
   },
   "type": "module",
   "version": "0.8.0"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["eslint.config.mjs", "dist", "scripts", "tests"]
+}


### PR DESCRIPTION
## Problem

Plugin fails to load in server/CLI mode (`opencode run`) with errors like:
```
Export named 'OTLPLogExporter' not found in module
```

Works fine in TUI mode. Seems like a difference in plugin loading behaviour between TUI and other modes.



## Root Cause

_Best effort explanation from AI below_ -

> The conditions: ["browser"] build setting (in Opencode) affects how the main thread resolves CJS modules at runtime, but Worker threads get a fresh module resolution context that behaves more like standalone bun. This is a Bun compiled binary quirk, not documented behavior — it's the most plausible explanation for why TUI (Worker thread) works while server/CLI (main thread) doesn't.
The bundled JS fix works because it resolves all imports at build time, eliminating runtime CJS/ESM interop entirely.


## Fix

Pre-bundle all dependencies into a single JavaScript file using `bun build`, which resolves imports at build time and avoids CJS/ESM interop issues at runtime.

`bun build` resolves all imports at build time, inlining the CJS modules into a single JavaScript file. The named exports are extracted during the build, not at runtime. When opencode loads the bundled file, there are no CJS modules left to interop with — everything is already ESM.

### Changes

1. **Add `build` script**: `bun build src/index.ts --outdir=./dist --target=node && tsc -p tsconfig.build.json`
2. **Update `exports`/`main`/`module`** to point to `dist/index.js`
3. **Add `./server` export** for explicit server mode entry point
4. **Add `types` condition** to exports map and top-level `types` field for TypeScript consumers
5. **Add `tsconfig.build.json`** to emit declaration files alongside bundled JS
6. **Add `prepack` hook** (instead of `prepublishOnly`) to ensure build runs before npm publish, npm pack, and when installing from git
7. **Update `files`** to ship `dist/` instead of `src/`

## Verification

I have verified that it works manually via -
1. local file path
2. pushed fork to [npm](https://www.npmjs.com/package/opencode-plugin-otel-fork) and tested live with it.

Happy to delete the package after fix is merged.

Fixes #35