### PR TITLE
feat(otel): refresh dynamic headers on auth failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An [opencode](https://opencode.ai) plugin that exports telemetry via OpenTelemet
 - [Configuration](#configuration)
   - [Quick start](#quick-start)
   - [Headers and resource attributes](#headers-and-resource-attributes)
+  - [Dynamic headers](#dynamic-headers)
   - [Disabling specific metrics](#disabling-specific-metrics)
   - [Datadog example](#datadog-example)
   - [Honeycomb example](#honeycomb-example)
@@ -89,6 +90,7 @@ All configuration is via environment variables. Set them in your shell profile (
 | `OPENCODE_METRIC_PREFIX` | `opencode.` | Prefix for all metric names (e.g. set to `claude_code.` for Claude Code dashboard compatibility) |
 | `OPENCODE_DISABLE_METRICS` | _(unset)_ | Comma-separated list of metric name suffixes to disable (e.g. `cache.count,session.duration`) |
 | `OPENCODE_OTLP_HEADERS` | _(unset)_ | Comma-separated `key=value` headers added to all OTLP exports. **Keep out of version control — may contain sensitive auth tokens.** |
+| `OPENCODE_OTLP_HEADERS_HELPER` | _(unset)_ | Executable script/binary that returns dynamic OTLP headers as JSON after an auth failure. Helper headers override `OPENCODE_OTLP_HEADERS`. |
 | `OPENCODE_RESOURCE_ATTRIBUTES` | _(unset)_ | Comma-separated `key=value` pairs merged into the OTel resource. Example: `service.version=1.2.3,deployment.environment=production` |
 | `OPENCODE_OTLP_METRICS_TEMPORALITY` | _(unset)_ | Metrics aggregation temporality: `delta`, `cumulative`, or `lowmemory`. Required for Datadog (`delta`). Copied to `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. |
 
@@ -114,6 +116,23 @@ export OPENCODE_RESOURCE_ATTRIBUTES="service.version=1.2.3,deployment.environmen
 ```
 
 > **Security note:** `OPENCODE_OTLP_HEADERS` typically contains auth tokens. Set it in your shell profile (`~/.zshrc`, `~/.bashrc`) or a secrets manager — never commit it to version control or print it in CI logs.
+
+### Dynamic headers
+
+Use `OPENCODE_OTLP_HEADERS_HELPER` when your collector requires short-lived authentication tokens. The helper is run only after an OTLP export fails with an authentication error (`401`/`403` for HTTP or `UNAUTHENTICATED`/`PERMISSION_DENIED` for gRPC). The plugin refreshes headers, rebuilds the exporter, and retries the failed export once.
+
+```bash
+export OPENCODE_OTLP_HEADERS_HELPER=/path/to/opencode-otel-headers.sh
+```
+
+The helper must be executable and print a JSON object to stdout:
+
+```bash
+#!/bin/sh
+printf '{"Authorization":"Bearer %s"}' "$(gcloud auth print-access-token)"
+```
+
+If `OPENCODE_OTLP_HEADERS` is also set, helper-provided headers override static headers with the same name. Header values are never logged.
 
 ### Disabling specific metrics
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ The helper must be executable and print a JSON object to stdout:
 
 ```bash
 #!/bin/sh
-printf '{"Authorization":"Bearer %s"}' "$(gcloud auth print-access-token)"
+printf '{"Authorization":"Bearer %s"}' "$(get-token.sh)"
 ```
+
+For a Cloud Run collector using IAM authentication, `get-token.sh` might be `gcloud auth print-identity-token`.
 
 If `OPENCODE_OTLP_HEADERS` is also set, helper-provided headers override static headers with the same name. Header values are never logged.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type PluginConfig = {
   logsInterval: number
   metricPrefix: string
   otlpHeaders: string | undefined
+  otlpHeadersHelper: string | undefined
   resourceAttributes: string | undefined
   metricsTemporality: MetricsTemporality | undefined
   disabledMetrics: Set<string>
@@ -38,6 +39,7 @@ export function parseEnvInt(key: string, fallback: number): number {
  */
 export function loadConfig(): PluginConfig {
   const otlpHeaders = process.env["OPENCODE_OTLP_HEADERS"]
+  const otlpHeadersHelper = process.env["OPENCODE_OTLP_HEADERS_HELPER"]
   const resourceAttributes = process.env["OPENCODE_RESOURCE_ATTRIBUTES"]
   const rawTemporality = process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
   const protocol = process.env["OPENCODE_OTLP_PROTOCOL"]
@@ -81,6 +83,7 @@ export function loadConfig(): PluginConfig {
     logsInterval: parseEnvInt("OPENCODE_OTLP_LOGS_INTERVAL", 5000),
     metricPrefix: process.env["OPENCODE_METRIC_PREFIX"] ?? "opencode.",
     otlpHeaders,
+    otlpHeadersHelper,
     resourceAttributes,
     metricsTemporality,
     disabledMetrics,

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,276 @@
+import { createRequire } from "module"
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core"
+import type { PushMetricExporter, ResourceMetrics, InstrumentType } from "@opentelemetry/sdk-metrics"
+import type { AggregationOption } from "@opentelemetry/sdk-metrics/build/src/view/AggregationOption"
+import type { AggregationTemporality } from "@opentelemetry/sdk-metrics/build/src/export/AggregationTemporality"
+import type { SpanExporter, ReadableSpan } from "@opentelemetry/sdk-trace-base"
+import type { LogRecordExporter, ReadableLogRecord } from "@opentelemetry/sdk-logs"
+import type { Metadata } from "@grpc/grpc-js"
+
+const require = createRequire(import.meta.url)
+
+type Exporter<T> = {
+  export(items: T, resultCallback: (result: ExportResult) => void): void
+  shutdown(): Promise<void>
+  forceFlush?(): Promise<void>
+}
+
+export type HeadersMap = Record<string, string>
+
+export function parseOtlpHeaders(raw: string | undefined): HeadersMap {
+  if (!raw) return {}
+  const headers: HeadersMap = {}
+  for (const pair of raw.split(",")) {
+    const idx = pair.indexOf("=")
+    if (idx > 0) {
+      const key = pair.slice(0, idx).trim()
+      const val = pair.slice(idx + 1).trim()
+      if (key) headers[key] = val
+    }
+  }
+  return headers
+}
+
+export function createGrpcMetadata(headers: HeadersMap): Metadata {
+  const { Metadata } = require("@grpc/grpc-js") as typeof import("@grpc/grpc-js")
+  const metadata = new Metadata()
+  for (const [key, value] of Object.entries(headers)) metadata.set(key, value)
+  return metadata
+}
+
+export function isAuthFailure(error: unknown): boolean {
+  if (!error) return false
+  const err = error as Record<string, unknown>
+  const numericStatus = Number(err["status"] ?? err["statusCode"] ?? err["code"])
+  if ([401, 403, 7, 16].includes(numericStatus)) return true
+  const message = error instanceof Error ? error.message : String(error)
+  return /\b(401|403)\b|unauthenticated|permission denied|unauthorized|forbidden/i.test(message)
+}
+
+export class DynamicHeaders {
+  private headers: HeadersMap
+  private version = 0
+  private refreshPromise: Promise<number> | undefined
+
+  constructor(
+    private readonly staticHeaders: HeadersMap,
+    private readonly helper: string | undefined,
+  ) {
+    this.headers = { ...staticHeaders }
+  }
+
+  current(): HeadersMap {
+    return { ...this.headers }
+  }
+
+  currentVersion(): number {
+    return this.version
+  }
+
+  refresh(): Promise<number> {
+    if (!this.helper) return Promise.resolve(this.version)
+    if (!this.refreshPromise) {
+      this.refreshPromise = this.runHelper()
+        .then((helperHeaders) => {
+          const next = { ...this.staticHeaders, ...helperHeaders }
+          const changed = headerSignature(next) !== headerSignature(this.headers)
+          this.headers = next
+          if (changed) this.version += 1
+          return this.version
+        })
+        .finally(() => {
+          this.refreshPromise = undefined
+        })
+    }
+    return this.refreshPromise
+  }
+
+  private async runHelper(): Promise<HeadersMap> {
+    const proc = Bun.spawn([this.helper!], { stdout: "pipe", stderr: "pipe" })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    if (exitCode !== 0) {
+      const detail = stderr.trim() || `exit code ${exitCode}`
+      throw new Error(`OTLP headers helper failed: ${detail}`)
+    }
+    const parsed = JSON.parse(stdout) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("OTLP headers helper must return a JSON object")
+    }
+    const headers: HeadersMap = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value !== "string") throw new Error(`OTLP headers helper returned non-string value for ${key}`)
+      headers[key] = value
+    }
+    return headers
+  }
+}
+
+export class RefreshingMetricExporter implements PushMetricExporter {
+  private exporter: PushMetricExporter
+  private headersVersion: number
+
+  constructor(
+    private readonly createExporter: (headers: HeadersMap) => PushMetricExporter,
+    private readonly dynamicHeaders: DynamicHeaders,
+  ) {
+    this.exporter = createExporter(dynamicHeaders.current())
+    this.headersVersion = dynamicHeaders.currentVersion()
+  }
+
+  export(metrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): void {
+    exportWithAuthRetry(this, metrics, resultCallback)
+  }
+
+  forceFlush(): Promise<void> {
+    return this.exporter.forceFlush()
+  }
+
+  shutdown(): Promise<void> {
+    return this.exporter.shutdown()
+  }
+
+  selectAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality {
+    return this.exporter.selectAggregationTemporality!(instrumentType)
+  }
+
+  selectAggregation(instrumentType: InstrumentType): AggregationOption {
+    return this.exporter.selectAggregation!(instrumentType)
+  }
+
+  _exporter(): PushMetricExporter {
+    return this.exporter
+  }
+
+  _replaceExporter(version: number): void {
+    const old = this.exporter
+    this.exporter = this.createExporter(this.dynamicHeaders.current())
+    this.headersVersion = version
+    old.shutdown().catch(() => {})
+  }
+
+  _refreshHeaders(): Promise<number> {
+    return this.dynamicHeaders.refresh()
+  }
+
+  _headersVersion(): number {
+    return this.headersVersion
+  }
+}
+
+export class RefreshingSpanExporter implements SpanExporter {
+  private exporter: SpanExporter
+  private headersVersion: number
+
+  constructor(
+    private readonly createExporter: (headers: HeadersMap) => SpanExporter,
+    private readonly dynamicHeaders: DynamicHeaders,
+  ) {
+    this.exporter = createExporter(dynamicHeaders.current())
+    this.headersVersion = dynamicHeaders.currentVersion()
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    exportWithAuthRetry(this, spans, resultCallback)
+  }
+
+  forceFlush(): Promise<void> {
+    return this.exporter.forceFlush?.() ?? Promise.resolve()
+  }
+
+  shutdown(): Promise<void> {
+    return this.exporter.shutdown()
+  }
+
+  _exporter(): SpanExporter {
+    return this.exporter
+  }
+
+  _replaceExporter(version: number): void {
+    const old = this.exporter
+    this.exporter = this.createExporter(this.dynamicHeaders.current())
+    this.headersVersion = version
+    old.shutdown().catch(() => {})
+  }
+
+  _refreshHeaders(): Promise<number> {
+    return this.dynamicHeaders.refresh()
+  }
+
+  _headersVersion(): number {
+    return this.headersVersion
+  }
+}
+
+export class RefreshingLogExporter implements LogRecordExporter {
+  private exporter: LogRecordExporter
+  private headersVersion: number
+
+  constructor(
+    private readonly createExporter: (headers: HeadersMap) => LogRecordExporter,
+    private readonly dynamicHeaders: DynamicHeaders,
+  ) {
+    this.exporter = createExporter(dynamicHeaders.current())
+    this.headersVersion = dynamicHeaders.currentVersion()
+  }
+
+  export(logs: ReadableLogRecord[], resultCallback: (result: ExportResult) => void): void {
+    exportWithAuthRetry(this, logs, resultCallback)
+  }
+
+  shutdown(): Promise<void> {
+    return this.exporter.shutdown()
+  }
+
+  _exporter(): LogRecordExporter {
+    return this.exporter
+  }
+
+  _replaceExporter(version: number): void {
+    const old = this.exporter
+    this.exporter = this.createExporter(this.dynamicHeaders.current())
+    this.headersVersion = version
+    old.shutdown().catch(() => {})
+  }
+
+  _refreshHeaders(): Promise<number> {
+    return this.dynamicHeaders.refresh()
+  }
+
+  _headersVersion(): number {
+    return this.headersVersion
+  }
+}
+
+function exportWithAuthRetry<T>(
+  wrapper: {
+    _exporter(): Exporter<T>
+    _replaceExporter(version: number): void
+    _refreshHeaders(): Promise<number>
+    _headersVersion(): number
+  },
+  items: T,
+  resultCallback: (result: ExportResult) => void,
+): void {
+  wrapper._exporter().export(items, (result) => {
+    if (result.code !== ExportResultCode.FAILED || !isAuthFailure(result.error)) {
+      resultCallback(result)
+      return
+    }
+    wrapper._refreshHeaders()
+      .then((version) => {
+        if (version !== wrapper._headersVersion()) wrapper._replaceExporter(version)
+        wrapper._exporter().export(items, resultCallback)
+      })
+      .catch((error: unknown) => {
+        resultCallback({ code: ExportResultCode.FAILED, error: error instanceof Error ? error : new Error(String(error)) })
+      })
+  })
+}
+
+function headerSignature(headers: HeadersMap): string {
+  return JSON.stringify(Object.entries(headers).sort(([a], [b]) => a.localeCompare(b)))
+}

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,19 +1,21 @@
 import { createRequire } from "module"
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core"
-import type { PushMetricExporter, ResourceMetrics, InstrumentType } from "@opentelemetry/sdk-metrics"
-import type { AggregationOption } from "@opentelemetry/sdk-metrics/build/src/view/AggregationOption"
-import type { AggregationTemporality } from "@opentelemetry/sdk-metrics/build/src/export/AggregationTemporality"
+import type { PushMetricExporter, ResourceMetrics } from "@opentelemetry/sdk-metrics"
 import type { SpanExporter, ReadableSpan } from "@opentelemetry/sdk-trace-base"
 import type { LogRecordExporter, ReadableLogRecord } from "@opentelemetry/sdk-logs"
 import type { Metadata } from "@grpc/grpc-js"
 
 const require = createRequire(import.meta.url)
+const DEFAULT_HELPER_TIMEOUT_MS = 5000
 
 type Exporter<T> = {
   export(items: T, resultCallback: (result: ExportResult) => void): void
   shutdown(): Promise<void>
   forceFlush?(): Promise<void>
 }
+
+type SelectAggregation = NonNullable<PushMetricExporter["selectAggregation"]>
+type SelectAggregationTemporality = NonNullable<PushMetricExporter["selectAggregationTemporality"]>
 
 export type HeadersMap = Record<string, string>
 
@@ -55,6 +57,7 @@ export class DynamicHeaders {
   constructor(
     private readonly staticHeaders: HeadersMap,
     private readonly helper: string | undefined,
+    private readonly helperTimeoutMs = DEFAULT_HELPER_TIMEOUT_MS,
   ) {
     this.headers = { ...staticHeaders }
   }
@@ -86,12 +89,20 @@ export class DynamicHeaders {
   }
 
   private async runHelper(): Promise<HeadersMap> {
-    const proc = Bun.spawn([this.helper!], { stdout: "pipe", stderr: "pipe" })
+    const proc = Bun.spawn([this.helper!], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: this.helperTimeoutMs,
+      killSignal: "SIGTERM",
+    })
     const [stdout, stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
       proc.exited,
     ])
+    if (proc.signalCode) {
+      throw new Error(`OTLP headers helper was terminated by ${proc.signalCode}`)
+    }
     if (exitCode !== 0) {
       const detail = stderr.trim() || `exit code ${exitCode}`
       throw new Error(`OTLP headers helper failed: ${detail}`)
@@ -133,11 +144,13 @@ export class RefreshingMetricExporter implements PushMetricExporter {
     return this.exporter.shutdown()
   }
 
-  selectAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality {
+  selectAggregationTemporality(
+    instrumentType: Parameters<SelectAggregationTemporality>[0],
+  ): ReturnType<SelectAggregationTemporality> {
     return this.exporter.selectAggregationTemporality!(instrumentType)
   }
 
-  selectAggregation(instrumentType: InstrumentType): AggregationOption {
+  selectAggregation(instrumentType: Parameters<SelectAggregation>[0]): ReturnType<SelectAggregation> {
     return this.exporter.selectAggregation!(instrumentType)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,10 +53,12 @@ export const OtelPlugin: Plugin = async ({ project, client }) => {
     metricsInterval: config.metricsInterval,
     logsInterval: config.logsInterval,
     metricPrefix: config.metricPrefix,
+    headersHelperSet: !!config.otlpHeadersHelper,
   })
 
   await log("debug", "config loaded", {
     headersSet: !!config.otlpHeaders,
+    headersHelperSet: !!config.otlpHeadersHelper,
     resourceAttributesSet: !!config.resourceAttributes,
   })
 
@@ -76,6 +78,8 @@ export const OtelPlugin: Plugin = async ({ project, client }) => {
     config.metricsInterval,
     config.logsInterval,
     PLUGIN_VERSION,
+    config.otlpHeaders,
+    config.otlpHeadersHelper,
   )
   await log("info", "OTel SDK initialized")
 

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -13,6 +13,15 @@ import { resourceFromAttributes } from "@opentelemetry/resources"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
 import { ATTR_HOST_ARCH } from "@opentelemetry/semantic-conventions/incubating"
 import type { Instruments } from "./types.ts"
+import {
+  createGrpcMetadata,
+  DynamicHeaders,
+  parseOtlpHeaders,
+  RefreshingLogExporter,
+  RefreshingMetricExporter,
+  RefreshingSpanExporter,
+  type HeadersMap,
+} from "./headers.ts"
 
 /**
  * Builds an OTel `Resource` seeded with `service.name`, `app.version`, `os.type`, and
@@ -65,17 +74,30 @@ export function setupOtel(
   metricsInterval: number,
   logsInterval: number,
   version: string,
+  otlpHeaders?: string,
+  otlpHeadersHelper?: string,
 ): OtelProviders {
   const resource = buildResource(version)
-  const metricExporter = protocol === "http/protobuf"
-    ? new OTLPHttpMetricExporter({ url: buildHttpSignalUrl(endpoint, "metrics") })
-    : new OTLPMetricExporter({ url: endpoint })
-  const logExporter = protocol === "http/protobuf"
-    ? new OTLPHttpLogExporter({ url: buildHttpSignalUrl(endpoint, "logs") })
-    : new OTLPLogExporter({ url: endpoint })
-  const traceExporter = protocol === "http/protobuf"
-    ? new OTLPHttpTraceExporter({ url: buildHttpSignalUrl(endpoint, "traces") })
-    : new OTLPTraceExporter({ url: endpoint })
+  const staticHeaders = parseOtlpHeaders(otlpHeaders)
+  const dynamicHeaders = new DynamicHeaders(staticHeaders, otlpHeadersHelper)
+  const makeMetricExporter = (headers: HeadersMap) => protocol === "http/protobuf"
+    ? new OTLPHttpMetricExporter({ url: buildHttpSignalUrl(endpoint, "metrics"), headers })
+    : new OTLPMetricExporter({ url: endpoint, metadata: createGrpcMetadata(headers) })
+  const makeLogExporter = (headers: HeadersMap) => protocol === "http/protobuf"
+    ? new OTLPHttpLogExporter({ url: buildHttpSignalUrl(endpoint, "logs"), headers })
+    : new OTLPLogExporter({ url: endpoint, metadata: createGrpcMetadata(headers) })
+  const makeTraceExporter = (headers: HeadersMap) => protocol === "http/protobuf"
+    ? new OTLPHttpTraceExporter({ url: buildHttpSignalUrl(endpoint, "traces"), headers })
+    : new OTLPTraceExporter({ url: endpoint, metadata: createGrpcMetadata(headers) })
+  const metricExporter = otlpHeadersHelper
+    ? new RefreshingMetricExporter(makeMetricExporter, dynamicHeaders)
+    : makeMetricExporter(staticHeaders)
+  const logExporter = otlpHeadersHelper
+    ? new RefreshingLogExporter(makeLogExporter, dynamicHeaders)
+    : makeLogExporter(staticHeaders)
+  const traceExporter = otlpHeadersHelper
+    ? new RefreshingSpanExporter(makeTraceExporter, dynamicHeaders)
+    : makeTraceExporter(staticHeaders)
 
   const meterProvider = new MeterProvider({
     resource,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -48,6 +48,7 @@ describe("loadConfig", () => {
     "OPENCODE_OTLP_METRICS_INTERVAL",
     "OPENCODE_OTLP_LOGS_INTERVAL",
     "OPENCODE_OTLP_HEADERS",
+    "OPENCODE_OTLP_HEADERS_HELPER",
     "OPENCODE_RESOURCE_ATTRIBUTES",
     "OPENCODE_OTLP_METRICS_TEMPORALITY",
     "OPENCODE_DISABLE_METRICS",
@@ -108,6 +109,11 @@ describe("loadConfig", () => {
     process.env["OPENCODE_OTLP_HEADERS"] = "api-key=abc123"
     loadConfig()
     expect(process.env["OTEL_EXPORTER_OTLP_HEADERS"]).toBe("api-key=abc123")
+  })
+
+  test("reads OPENCODE_OTLP_HEADERS_HELPER", () => {
+    process.env["OPENCODE_OTLP_HEADERS_HELPER"] = "/tmp/otel-headers"
+    expect(loadConfig().otlpHeadersHelper).toBe("/tmp/otel-headers")
   })
 
   test("copies OPENCODE_RESOURCE_ATTRIBUTES to OTEL_RESOURCE_ATTRIBUTES", () => {

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { ExportResultCode, type ExportResult } from "@opentelemetry/core"
+import { DynamicHeaders, isAuthFailure, parseOtlpHeaders, RefreshingSpanExporter } from "../src/headers.ts"
+import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base"
+
+let tempDir: string | undefined
+
+afterEach(async () => {
+  if (tempDir) await rm(tempDir, { recursive: true, force: true })
+  tempDir = undefined
+})
+
+class FakeSpanExporter implements SpanExporter {
+  readonly calls: string[][] = []
+  readonly shutdowns: string[][]
+
+  constructor(
+    private readonly headers: Record<string, string>,
+    private readonly results: ExportResult[],
+    shutdowns: string[][],
+  ) {
+    this.shutdowns = shutdowns
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    this.calls.push(Object.keys(this.headers).sort())
+    resultCallback(this.results.shift() ?? { code: ExportResultCode.SUCCESS })
+  }
+
+  shutdown(): Promise<void> {
+    this.shutdowns.push(Object.keys(this.headers).sort())
+    return Promise.resolve()
+  }
+}
+
+describe("parseOtlpHeaders", () => {
+  test("parses comma-separated key value pairs", () => {
+    expect(parseOtlpHeaders("Authorization=Bearer a, x-api-key = b=c ")).toEqual({
+      Authorization: "Bearer a",
+      "x-api-key": "b=c",
+    })
+  })
+
+  test("ignores empty and malformed segments", () => {
+    expect(parseOtlpHeaders("good=value,bad,no-key=, trailing=value,")).toEqual({
+      good: "value",
+      "no-key": "",
+      trailing: "value",
+    })
+  })
+})
+
+describe("isAuthFailure", () => {
+  test("matches HTTP auth status codes", () => {
+    expect(isAuthFailure(Object.assign(new Error("Unauthorized"), { statusCode: 401 }))).toBe(true)
+    expect(isAuthFailure(Object.assign(new Error("Forbidden"), { status: 403 }))).toBe(true)
+  })
+
+  test("matches gRPC auth status codes", () => {
+    expect(isAuthFailure(Object.assign(new Error("UNAUTHENTICATED"), { code: 16 }))).toBe(true)
+    expect(isAuthFailure(Object.assign(new Error("PERMISSION_DENIED"), { code: 7 }))).toBe(true)
+  })
+
+  test("does not match unrelated failures", () => {
+    expect(isAuthFailure(Object.assign(new Error("Unavailable"), { code: 14 }))).toBe(false)
+  })
+})
+
+describe("DynamicHeaders", () => {
+  test("merges helper headers over static headers", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "otel-headers-"))
+    const helper = join(tempDir, "helper.sh")
+    await Bun.write(helper, "#!/bin/sh\nprintf '%s' '{\"Authorization\":\"Bearer dynamic\",\"x-extra\":\"1\"}'\n")
+    await Bun.spawn(["chmod", "+x", helper]).exited
+
+    const headers = new DynamicHeaders({ Authorization: "Bearer static", static: "1" }, helper)
+    await expect(headers.refresh()).resolves.toBe(1)
+    expect(headers.current()).toEqual({ Authorization: "Bearer dynamic", static: "1", "x-extra": "1" })
+  })
+
+  test("shares one in-flight helper refresh", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "otel-headers-"))
+    const countFile = join(tempDir, "count")
+    const helper = join(tempDir, "helper.sh")
+    await Bun.write(helper, `#!/bin/sh\ncount=$(cat "${countFile}" 2>/dev/null || printf 0)\ncount=$((count + 1))\nprintf '%s' "$count" > "${countFile}"\nsleep 0.1\nprintf '%s' '{"Authorization":"Bearer dynamic"}'\n`)
+    await Bun.spawn(["chmod", "+x", helper]).exited
+
+    const headers = new DynamicHeaders({}, helper)
+    await Promise.all([headers.refresh(), headers.refresh(), headers.refresh()])
+    expect(await Bun.file(countFile).text()).toBe("1")
+  })
+})
+
+describe("RefreshingSpanExporter", () => {
+  test("refreshes headers and retries once after auth failure", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "otel-headers-"))
+    const helper = join(tempDir, "helper.sh")
+    await Bun.write(helper, "#!/bin/sh\nprintf '%s' '{\"Authorization\":\"Bearer dynamic\"}'\n")
+    await Bun.spawn(["chmod", "+x", helper]).exited
+
+    const dynamicHeaders = new DynamicHeaders({ Authorization: "Bearer static" }, helper)
+    const shutdowns: string[][] = []
+    const results = [
+      { code: ExportResultCode.FAILED, error: Object.assign(new Error("Unauthorized"), { statusCode: 401 }) },
+      { code: ExportResultCode.SUCCESS },
+    ]
+    const seenHeaders: Record<string, string>[] = []
+    const exporter = new RefreshingSpanExporter((headers) => {
+      seenHeaders.push(headers)
+      return new FakeSpanExporter(headers, results, shutdowns)
+    }, dynamicHeaders)
+
+    const result = await new Promise<ExportResult>((resolve) => exporter.export([], resolve))
+    expect(result.code).toBe(ExportResultCode.SUCCESS)
+    expect(seenHeaders).toEqual([{ Authorization: "Bearer static" }, { Authorization: "Bearer dynamic" }])
+    expect(shutdowns).toEqual([["Authorization"]])
+  })
+})

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -92,6 +92,16 @@ describe("DynamicHeaders", () => {
     await Promise.all([headers.refresh(), headers.refresh(), headers.refresh()])
     expect(await Bun.file(countFile).text()).toBe("1")
   })
+
+  test("fails helper refresh when the helper times out", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "otel-headers-"))
+    const helper = join(tempDir, "helper.sh")
+    await Bun.write(helper, "#!/bin/sh\nsleep 1\n")
+    await Bun.spawn(["chmod", "+x", helper]).exited
+
+    const headers = new DynamicHeaders({}, helper, 50)
+    await expect(headers.refresh()).rejects.toThrow("OTLP headers helper was terminated")
+  })
 })
 
 describe("RefreshingSpanExporter", () => {


### PR DESCRIPTION
## Summary
- Add `OPENCODE_OTLP_HEADERS_HELPER` for executable helpers that return dynamic OTLP headers as JSON.
- Refresh headers only after HTTP/gRPC auth export failures and retry the failed export once.
- Document dynamic headers and add tests for parsing, auth detection, refresh sharing, and retry behavior.

## Verification
- `bun run typecheck`
- `bun test`
- `bun run lint`
- `bun run check:jsdoc-coverage`

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic OTLP headers via OPENCODE_OTLP_HEADERS_HELPER: helper-provided headers override static headers, exported data retries once after auth failures, and exporters refresh headers transparently.

* **Documentation**
  * README updated with a “Dynamic headers” section, usage examples, header precedence rules, retry behavior, and assurance that header values are never logged.

* **Tests**
  * Added tests for header parsing, auth-failure detection, dynamic refresh behavior, and export retry logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->