### PR TITLE
feat(otel): prewarm dynamic OTLP headers helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,16 @@ export OPENCODE_RESOURCE_ATTRIBUTES="service.version=1.2.3,deployment.environmen
 
 ### Dynamic headers
 
-Use `OPENCODE_OTLP_HEADERS_HELPER` when your collector requires short-lived authentication tokens. The helper is run only after an OTLP export fails with an authentication error (`401`/`403` for HTTP or `UNAUTHENTICATED`/`PERMISSION_DENIED` for gRPC). The plugin refreshes headers, rebuilds the exporter, and retries the failed export once.
+Use `OPENCODE_OTLP_HEADERS_HELPER` when your collector requires short-lived authentication tokens. When this is set, the plugin prewarms the helper once during startup so the first export can use fresh credentials. If a later OTLP export fails with an authentication error (`401`/`403` for HTTP or `UNAUTHENTICATED`/`PERMISSION_DENIED` for gRPC), the plugin refreshes headers again, rebuilds the exporter, and retries the failed export once.
 
 ```bash
 export OPENCODE_OTLP_HEADERS_HELPER=/path/to/opencode-otel-headers.sh
+```
+
+Use an absolute helper path. If you need the path to follow the current project, `OPENCODE_OTLP_HEADERS_HELPER` also supports `${PROJECT_ROOT}`, `${WORKTREE}`, and `${DIRECTORY}` placeholders.
+
+```bash
+export OPENCODE_OTLP_HEADERS_HELPER='${PROJECT_ROOT}/scripts/opencode-otel-headers.sh'
 ```
 
 The helper must be executable and print a JSON object to stdout:

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,19 @@ export function loadConfig(): PluginConfig {
   }
 }
 
+export function resolveHelperPath(
+  helper: string | undefined,
+  directory: string | undefined,
+  worktree: string | undefined,
+): string | undefined {
+  if (!helper) return helper
+  const projectRoot = worktree ?? directory ?? process.cwd()
+  return helper
+    .replaceAll("${PROJECT_ROOT}", projectRoot)
+    .replaceAll("${WORKTREE}", worktree ?? projectRoot)
+    .replaceAll("${DIRECTORY}", directory ?? projectRoot)
+}
+
 /**
  * Resolves an opencode log level string to a `Level`.
  * Returns `current` unchanged when the input does not match a known level.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type {
   EventCommandExecuted,
 } from "@opencode-ai/sdk"
 import { LEVELS, type Level, type HandlerContext } from "./types.ts"
-import { loadConfig, resolveLogLevel } from "./config.ts"
+import { loadConfig, resolveHelperPath, resolveLogLevel } from "./config.ts"
 import { probeEndpoint } from "./probe.ts"
 import { setupOtel, createInstruments } from "./otel.ts"
 import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSessionStatus } from "./handlers/session.ts"
@@ -32,8 +32,9 @@ const PLUGIN_VERSION: string = (pkg as { version?: string }).version ?? "unknown
  * Instruments metrics (sessions, tokens, cost, lines of code, commits, tool durations)
  * and structured log events. All instrumentation is gated on `OPENCODE_ENABLE_TELEMETRY`.
  */
-export const OtelPlugin: Plugin = async ({ project, client }) => {
+export const OtelPlugin: Plugin = async ({ project, client, directory, worktree }) => {
   const config = loadConfig()
+  const otlpHeadersHelper = resolveHelperPath(config.otlpHeadersHelper, directory, worktree)
   let minLevel: Level = "info"
 
   const log: HandlerContext["log"] = async (level, message, extra) => {
@@ -72,14 +73,14 @@ export const OtelPlugin: Plugin = async ({ project, client }) => {
     })
   }
 
-  const { meterProvider, loggerProvider, tracerProvider } = setupOtel(
+  const { meterProvider, loggerProvider, tracerProvider } = await setupOtel(
     config.endpoint,
     config.protocol,
     config.metricsInterval,
     config.logsInterval,
     PLUGIN_VERSION,
     config.otlpHeaders,
-    config.otlpHeadersHelper,
+    otlpHeadersHelper,
   )
   await log("info", "OTel SDK initialized")
 

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -68,7 +68,7 @@ export function buildHttpSignalUrl(endpoint: string, signal: "traces" | "metrics
  * `BasicTracerProvider` backed by OTLP exporters (gRPC or HTTP/protobuf)
  * pointed at `endpoint`, and registers them as the global providers.
  */
-export function setupOtel(
+export async function setupOtel(
   endpoint: string,
   protocol: "grpc" | "http/protobuf",
   metricsInterval: number,
@@ -76,10 +76,17 @@ export function setupOtel(
   version: string,
   otlpHeaders?: string,
   otlpHeadersHelper?: string,
-): OtelProviders {
+): Promise<OtelProviders> {
   const resource = buildResource(version)
   const staticHeaders = parseOtlpHeaders(otlpHeaders)
   const dynamicHeaders = new DynamicHeaders(staticHeaders, otlpHeadersHelper)
+  if (otlpHeadersHelper) {
+    try {
+      await dynamicHeaders.refresh()
+    } catch (error) {
+      console.warn("[opencode-plugin-otel] Failed to prewarm OTLP headers helper. Falling back to refresh-on-auth-failure.", error)
+    }
+  }
   const makeMetricExporter = (headers: HeadersMap) => protocol === "http/protobuf"
     ? new OTLPHttpMetricExporter({ url: buildHttpSignalUrl(endpoint, "metrics"), headers })
     : new OTLPMetricExporter({ url: endpoint, metadata: createGrpcMetadata(headers) })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { parseEnvInt, loadConfig, resolveLogLevel } from "../src/config.ts"
+import { parseEnvInt, loadConfig, resolveHelperPath, resolveLogLevel } from "../src/config.ts"
 
 describe("parseEnvInt", () => {
   test("returns fallback when env var is unset", () => {
@@ -275,5 +275,21 @@ describe("resolveLogLevel", () => {
   test("returns current level for unknown value", () => {
     expect(resolveLogLevel("verbose", "info")).toBe("info")
     expect(resolveLogLevel("", "warn")).toBe("warn")
+  })
+})
+
+describe("resolveHelperPath", () => {
+  test("returns undefined when helper is unset", () => {
+    expect(resolveHelperPath(undefined, "/repo/current", "/repo")).toBeUndefined()
+  })
+
+  test("expands project placeholders", () => {
+    expect(resolveHelperPath("${PROJECT_ROOT}/bin/helper.sh", "/repo/current", "/repo")).toBe("/repo/bin/helper.sh")
+    expect(resolveHelperPath("${WORKTREE}/bin/helper.sh", "/repo/current", "/repo")).toBe("/repo/bin/helper.sh")
+    expect(resolveHelperPath("${DIRECTORY}/bin/helper.sh", "/repo/current", "/repo")).toBe("/repo/current/bin/helper.sh")
+  })
+
+  test("falls back to directory when worktree is unavailable", () => {
+    expect(resolveHelperPath("${PROJECT_ROOT}/bin/helper.sh", "/repo/current", undefined)).toBe("/repo/current/bin/helper.sh")
   })
 })


### PR DESCRIPTION
## Summary
- prewarm the dynamic OTLP headers helper during telemetry startup so the first export can use fresh credentials
- keep refresh-on-auth-failure behavior and add explicit helper path placeholders for project-relative configuration
- document the helper path guidance and cover placeholder resolution with tests

## Verification
- bun run typecheck
- bun test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for path placeholders in OTLP header helper configurations (${PROJECT_ROOT}, ${WORKTREE}, ${DIRECTORY})
  * Failed OTLP exports now retry once automatically

* **Improvements**
  * OTLP headers helper is now prewarmed at startup for better performance
  * Header data is automatically refreshed and exporter rebuilt when authentication failures occur
  * Enhanced error handling for header helper operations with graceful fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->