### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Typecheck & Test


### PR DESCRIPTION
Potential fix for [https://github.com/DEVtheOPS/opencode-plugin-otel/security/code-scanning/1](https://github.com/DEVtheOPS/opencode-plugin-otel/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` so the workflow does not depend on repository/organization defaults.

Best fix (without changing behavior): define workflow-level permissions with least privilege, using:
- `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks.  
Edit region: near the top of `.github/workflows/ci.yml`, after the `on:` block and before `jobs:`.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined access permissions in the continuous integration workflow to improve the security posture of automated build and deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DEVtheOPS/opencode-plugin-otel/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->