### PR TITLE
fix(probe): reject scheme-less endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All configuration is via environment variables. Set them in your shell profile (
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENCODE_ENABLE_TELEMETRY` | *(unset)* | Set to any non-empty value to enable the plugin |
-| `OPENCODE_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint. For `grpc`, use the collector host/port. For `http/protobuf` and `http/json`, use the base URL and the plugin will append `/v1/traces`, `/v1/metrics`, and `/v1/logs`. |
+| `OPENCODE_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint. Always include a URL scheme. For `grpc`, use the collector URL (for example `http://localhost:4317` or `grpc://collector:4317`). For `http/protobuf` and `http/json`, use the base URL and the plugin will append `/v1/traces`, `/v1/metrics`, and `/v1/logs`. |
 | `OPENCODE_OTLP_PROTOCOL` | `grpc` | OTLP transport protocol: `grpc`, `http/protobuf`, or `http/json` |
 | `OPENCODE_OTLP_METRICS_INTERVAL` | `60000` | Metrics export interval in milliseconds |
 | `OPENCODE_OTLP_LOGS_INTERVAL` | `5000` | Logs export interval in milliseconds |
@@ -110,6 +110,8 @@ export OPENCODE_OTLP_ENDPOINT=http://localhost:4317
 export OPENCODE_OTLP_PROTOCOL=grpc
 opencode
 ```
+
+Always set `OPENCODE_OTLP_ENDPOINT` to a full URL with a scheme. Scheme-less values like `localhost:4317` are rejected.
 
 For `OPENCODE_OTLP_PROTOCOL=http/protobuf` or `OPENCODE_OTLP_PROTOCOL=http/json`, set `OPENCODE_OTLP_ENDPOINT` to the collector base URL rather than a per-signal path. The plugin expands it to `/v1/traces`, `/v1/metrics`, and `/v1/logs` automatically.
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -10,6 +10,7 @@ export type ProbeResult = { ok: boolean; ms: number; error?: string }
 export function parseEndpoint(endpoint: string): { host: string; port: number } | null {
   try {
     const url = new URL(endpoint)
+    if (!url.hostname) return null
     const defaultPort = url.protocol === "http:" ? 80 : url.protocol === "https:" ? 443 : 4317
     return { host: url.hostname, port: url.port ? parseInt(url.port, 10) : defaultPort }
   } catch {

--- a/tests/probe.test.ts
+++ b/tests/probe.test.ts
@@ -22,12 +22,17 @@ describe("parseEndpoint", () => {
   test("returns null for invalid URLs", () => {
     expect(parseEndpoint("not a url")).toBeNull()
   })
+
+  test("returns null for URLs without a hostname", () => {
+    expect(parseEndpoint("localhost:4317")).toBeNull()
+  })
 })
 
 describe("probeEndpoint", () => {
   test("returns error for malformed URL (no scheme)", async () => {
     const result = await probeEndpoint("localhost:4317")
     expect(result.ok).toBe(false)
+    expect(result.error).toContain("invalid endpoint URL")
     expect(result.error).toBeDefined()
   })
 


### PR DESCRIPTION
## Summary
- reject endpoint URLs that parse without a hostname
- restore the malformed no-scheme probe regression coverage
- clarify in the README that `OPENCODE_OTLP_ENDPOINT` must include a scheme

## Testing
- bun run typecheck
- bun test

Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that `OPENCODE_OTLP_ENDPOINT` requires full URLs with schemes (e.g., `http://localhost:4317`). Scheme-less values like `localhost:4317` are no longer accepted.

* **Bug Fixes**
  * Improved endpoint validation to reject malformed URLs without proper schemes or hostnames.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DEVtheOPS/opencode-plugin-otel/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->