### PR TITLE
fix(activity): detect git commits via tool_result event instead of command.executed

### DIFF
--- a/src/handlers/activity.ts
+++ b/src/handlers/activity.ts
@@ -1,5 +1,5 @@
 import { SeverityNumber } from "@opentelemetry/api-logs"
-import type { EventSessionDiff, EventCommandExecuted } from "@opencode-ai/sdk"
+import type { EventSessionDiff } from "@opencode-ai/sdk"
 import { agentAttrs, getSessionAgentMeta, isMetricEnabled, setBoundedMap } from "../util.ts"
 import type { HandlerContext } from "../types.ts"
 
@@ -64,19 +64,31 @@ export function handleSessionDiff(e: EventSessionDiff, ctx: HandlerContext) {
 
 const GIT_COMMIT_RE = /\bgit\s+commit(?![-\w])/
 
-/** Detects `git commit` invocations in bash tool calls and increments the commit counter and emits a `commit` log event. */
-export function handleCommandExecuted(e: EventCommandExecuted, ctx: HandlerContext) {
-  if (e.properties.name !== "bash") return
-  ctx.log("debug", "otel: command.executed (bash)", { sessionID: e.properties.sessionID, argumentsLength: e.properties.arguments.length })
-  if (!GIT_COMMIT_RE.test(e.properties.arguments)) return
-  const { agentName, agentType } = getSessionAgentMeta(e.properties.sessionID, ctx)
+/**
+ * Detects `git commit` invocations in completed bash tool calls and increments the
+ * commit counter and emits a `commit` log event. Called from the tool-completion
+ * branch of `handleMessagePartUpdated` — opencode's `command.executed` event covers
+ * slash commands only and never fires for bash tool calls.
+ */
+export function handleToolResult(
+  toolName: string,
+  toolInput: { [key: string]: unknown } | undefined,
+  sessionID: string,
+  ctx: HandlerContext,
+) {
+  if (toolName !== "bash") return
+  const input = toolInput ?? {}
+  const command = typeof input["command"] === "string" ? input["command"] : ""
+  const description = typeof input["description"] === "string" ? input["description"] : ""
+  if (!GIT_COMMIT_RE.test(command) && !GIT_COMMIT_RE.test(description)) return
+  const { agentName, agentType } = getSessionAgentMeta(sessionID, ctx)
 
   if (isMetricEnabled("commit.count", ctx)) {
     ctx.instruments.commitCounter.add(1, {
       ...ctx.commonAttrs,
-      "session.id": e.properties.sessionID,
+      "session.id": sessionID,
     })
-    ctx.log("debug", "otel: commit counter incremented", { sessionID: e.properties.sessionID })
+    ctx.log("debug", "otel: commit counter incremented", { sessionID })
   }
   ctx.emitLog({
     severityNumber: SeverityNumber.INFO,
@@ -86,7 +98,7 @@ export function handleCommandExecuted(e: EventCommandExecuted, ctx: HandlerConte
     body: "commit",
     attributes: {
       "event.name": "commit",
-      "session.id": e.properties.sessionID,
+      "session.id": sessionID,
       ...agentAttrs(agentName, agentType),
       ...ctx.commonAttrs,
     },

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -37,6 +37,7 @@ import {
   isTraceEnabled,
   resolveSessionTraceContext,
 } from "../util.ts"
+import { handleToolResult } from "./activity.ts"
 import type { HandlerContext } from "../types.ts"
 
 const OPENINFERENCE_SPAN_KIND = SemanticConventions.OPENINFERENCE_SPAN_KIND
@@ -372,6 +373,10 @@ export function handleMessagePartUpdated(e: EventMessagePartUpdated, ctx: Handle
     const sizeAttr = success
       ? { tool_result_size_bytes: Buffer.byteLength((toolPart.state as { output: string }).output, "utf8") }
       : { error: (toolPart.state as { error: string }).error }
+
+    if (success) {
+      handleToolResult(toolPart.tool, toolPart.state.input, toolPart.sessionID, ctx)
+    }
 
     ctx.emitLog({
       severityNumber: success ? SeverityNumber.INFO : SeverityNumber.ERROR,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import type {
   EventPermissionUpdated,
   EventPermissionReplied,
   EventSessionDiff,
-  EventCommandExecuted,
 } from "@opencode-ai/sdk"
 import { LEVELS, type Level, type HandlerContext } from "./types.ts"
 import { loadConfig, parseAttributePairs, resolveHelperPath, resolveLogLevel, type OtelPluginOptions } from "./config.ts"
@@ -24,7 +23,7 @@ import { remoteParentContext } from "./trace-context.ts"
 import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSessionStatus, handleRunStarted } from "./handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "./handlers/message.ts"
 import { handlePermissionUpdated, handlePermissionReplied } from "./handlers/permission.ts"
-import { handleSessionDiff, handleCommandExecuted } from "./handlers/activity.ts"
+import { handleSessionDiff } from "./handlers/activity.ts"
 import { agentAttrs, getSessionAgentMeta, setBoundedMap } from "./util.ts"
 import type { SessionTotals } from "./types.ts"
 
@@ -295,9 +294,6 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
           break
         case "session.diff":
           handleSessionDiff(event as EventSessionDiff, ctx)
-          break
-        case "command.executed":
-          handleCommandExecuted(event as EventCommandExecuted, ctx)
           break
         case "permission.updated":
           handlePermissionUpdated(event as EventPermissionUpdated, ctx)

--- a/tests/handlers/activity.test.ts
+++ b/tests/handlers/activity.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test"
-import { handleSessionDiff, handleCommandExecuted } from "../../src/handlers/activity.ts"
+import { handleSessionDiff, handleToolResult } from "../../src/handlers/activity.ts"
 import { makeCtx } from "../helpers.ts"
-import type { EventSessionDiff, EventCommandExecuted } from "@opencode-ai/sdk"
+import type { EventSessionDiff } from "@opencode-ai/sdk"
 
 function makeSessionDiff(
   sessionID: string,
@@ -14,13 +14,6 @@ function makeSessionDiff(
       diff: diffs.map((d) => ({ before: "", after: "", additions: d.additions, deletions: d.deletions, file: d.file })),
     },
   } as unknown as EventSessionDiff
-}
-
-function makeCommandExecuted(name: string, args: string, sessionID = "ses_1"): EventCommandExecuted {
-  return {
-    type: "command.executed",
-    properties: { name, arguments: args, sessionID, messageID: "msg_1" },
-  } as unknown as EventCommandExecuted
 }
 
 describe("handleSessionDiff", () => {
@@ -134,17 +127,18 @@ describe("handleSessionDiff", () => {
   })
 })
 
-describe("handleCommandExecuted", () => {
-  test("increments commit counter for git commit", () => {
+describe("handleToolResult", () => {
+  test("increments commit counter for git commit in bash command", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("bash", 'git commit -m "feat: add thing"'), ctx)
+    handleToolResult("bash", { command: 'git commit -m "feat: add thing"', description: "Commit changes" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(1)
+    expect(counters.commit.calls.at(0)!.attrs["session.id"]).toBe("ses_1")
   })
 
   test("emits commit log record", () => {
     const { ctx, logger } = makeCtx()
     ctx.sessionTotals.set("ses_1", { startMs: 0, tokens: 0, cost: 0, messages: 0, agent: "build", agentType: "primary" })
-    handleCommandExecuted(makeCommandExecuted("bash", "git commit -m 'fix: bug'"), ctx)
+    handleToolResult("bash", { command: "git commit -m 'fix: bug'", description: "" }, "ses_1", ctx)
     expect(logger.records).toHaveLength(1)
     expect(logger.records.at(0)!.body).toBe("commit")
     expect(logger.records.at(0)!.attributes?.["session.id"]).toBe("ses_1")
@@ -152,33 +146,51 @@ describe("handleCommandExecuted", () => {
     expect(logger.records.at(0)!.attributes?.["agent.type"]).toBe("primary")
   })
 
-  test("ignores non-bash commands", () => {
+  test("ignores non-bash tools", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("python", "git commit -m foo"), ctx)
+    handleToolResult("read", { command: "git commit -m foo", description: "" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(0)
   })
 
   test("ignores bash commands without git commit", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("bash", "npm install"), ctx)
+    handleToolResult("bash", { command: "npm install", description: "Install deps" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(0)
   })
 
   test("does not match git commit-graph", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("bash", "git commit-graph write"), ctx)
+    handleToolResult("bash", { command: "git commit-graph write", description: "" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(0)
   })
 
-  test("does not match string containing 'git commit' in echo", () => {
+  test("matches when git commit appears in echo argument", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("bash", 'echo "run git commit to save"'), ctx)
+    handleToolResult("bash", { command: 'echo "run git commit to save"', description: "" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(1)
   })
 
   test("matches git commit with --amend", () => {
     const { ctx, counters } = makeCtx()
-    handleCommandExecuted(makeCommandExecuted("bash", "git commit --amend --no-edit"), ctx)
+    handleToolResult("bash", { command: "git commit --amend --no-edit", description: "" }, "ses_1", ctx)
+    expect(counters.commit.calls).toHaveLength(1)
+  })
+
+  test("matches when description contains git commit", () => {
+    const { ctx, counters } = makeCtx()
+    handleToolResult("bash", { command: "/usr/bin/env sh -c 'foo'", description: "git commit the changes" }, "ses_1", ctx)
+    expect(counters.commit.calls).toHaveLength(1)
+  })
+
+  test("handles missing command and description fields", () => {
+    const { ctx, counters } = makeCtx()
+    handleToolResult("bash", {}, "ses_1", ctx)
+    expect(counters.commit.calls).toHaveLength(0)
+  })
+
+  test("does not double-count when both fields match", () => {
+    const { ctx, counters } = makeCtx()
+    handleToolResult("bash", { command: "git commit -m foo", description: "git commit changes" }, "ses_1", ctx)
     expect(counters.commit.calls).toHaveLength(1)
   })
 })

--- a/tests/handlers/disabled-metrics.test.ts
+++ b/tests/handlers/disabled-metrics.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from "bun:test"
 import { handleSessionCreated, handleSessionIdle, handleSessionStatus } from "../../src/handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated } from "../../src/handlers/message.ts"
-import { handleSessionDiff, handleCommandExecuted } from "../../src/handlers/activity.ts"
+import { handleSessionDiff, handleToolResult } from "../../src/handlers/activity.ts"
 import { makeCtx } from "../helpers.ts"
-import type { EventSessionCreated, EventSessionIdle, EventSessionStatus, EventMessageUpdated, EventMessagePartUpdated, EventSessionDiff, EventCommandExecuted } from "@opencode-ai/sdk"
+import type { EventSessionCreated, EventSessionIdle, EventSessionStatus, EventMessageUpdated, EventMessagePartUpdated, EventSessionDiff } from "@opencode-ai/sdk"
 
 function makeSessionCreated(sessionID: string): EventSessionCreated {
   return {
@@ -59,11 +59,8 @@ function makeSessionDiff(): EventSessionDiff {
   } as unknown as EventSessionDiff
 }
 
-function makeCommandExecuted(cmd: string): EventCommandExecuted {
-  return {
-    type: "command.executed",
-    properties: { sessionID: "ses_1", name: "bash", arguments: cmd },
-  } as unknown as EventCommandExecuted
+function bashCommit(command: string) {
+  return { command, description: "Create commit" }
 }
 
 describe("OPENCODE_DISABLE_METRICS", () => {
@@ -189,13 +186,13 @@ describe("OPENCODE_DISABLE_METRICS", () => {
   describe("commit.count disabled", () => {
     test("does not increment commit counter", () => {
       const { ctx, counters } = makeCtx("proj_test", ["commit.count"])
-      handleCommandExecuted(makeCommandExecuted("git commit -m 'test'"), ctx)
+      handleToolResult("bash", bashCommit("git commit -m 'test'"), "ses_1", ctx)
       expect(counters.commit.calls).toHaveLength(0)
     })
 
     test("still emits commit log record", () => {
       const { ctx, logger } = makeCtx("proj_test", ["commit.count"])
-      handleCommandExecuted(makeCommandExecuted("git commit -m 'test'"), ctx)
+      handleToolResult("bash", bashCommit("git commit -m 'test'"), "ses_1", ctx)
       expect(logger.records.at(0)!.body).toBe("commit")
     })
   })
@@ -247,7 +244,7 @@ describe("OPENCODE_DISABLE_METRICS", () => {
       handleSessionIdle(makeSessionIdle("ses_1"), ctx)
       handleSessionStatus(makeSessionStatus("ses_1"), ctx)
       handleSessionDiff(makeSessionDiff(), ctx)
-      handleCommandExecuted(makeCommandExecuted("git commit -m 'test'"), ctx)
+      handleToolResult("bash", bashCommit("git commit -m 'test'"), "ses_1", ctx)
       await handleMessagePartUpdated(makeToolPart("running"), ctx)
       await handleMessagePartUpdated(makeToolPart("completed"), ctx)
       await handleMessagePartUpdated(subtaskEvent, ctx)

--- a/tests/handlers/disabled-signals.test.ts
+++ b/tests/handlers/disabled-signals.test.ts
@@ -2,10 +2,9 @@ import { describe, test, expect } from "bun:test"
 import { handleSessionCreated, handleSessionIdle } from "../../src/handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "../../src/handlers/message.ts"
 import { handlePermissionReplied } from "../../src/handlers/permission.ts"
-import { handleCommandExecuted } from "../../src/handlers/activity.ts"
+import { handleToolResult } from "../../src/handlers/activity.ts"
 import { makeCtx } from "../helpers.ts"
 import type {
-  EventCommandExecuted,
   EventMessagePartUpdated,
   EventMessageUpdated,
   EventPermissionReplied,
@@ -67,12 +66,7 @@ function makePermissionReplied(): EventPermissionReplied {
   } as unknown as EventPermissionReplied
 }
 
-function makeCommandExecuted(cmd: string): EventCommandExecuted {
-  return {
-    type: "command.executed",
-    properties: { sessionID: "ses_1", name: "bash", arguments: cmd },
-  } as unknown as EventCommandExecuted
-}
+
 
 describe("disabled logs", () => {
   test("suppresses OTLP logs while leaving metrics enabled", async () => {
@@ -96,7 +90,7 @@ describe("disabled logs", () => {
     await handleMessagePartUpdated(makeToolPartUpdated("running"), ctx)
     await handleMessagePartUpdated(makeToolPartUpdated("completed"), ctx)
     handlePermissionReplied(makePermissionReplied(), ctx)
-    handleCommandExecuted(makeCommandExecuted("git commit -m 'test'"), ctx)
+    handleToolResult("bash", { command: "git commit -m 'test'", description: "Commit test" }, "ses_1", ctx)
     handleSessionIdle(makeSessionIdle("ses_1"), ctx)
     expect(logger.records).toHaveLength(0)
   })


### PR DESCRIPTION
## Problem

`opencode.commit.count` never increments, regardless of how many `git commit` invocations a session makes.

## Root cause

The old `handleCommandExecuted` listens to `command.executed` events filtered by `name === "bash"`. But `command.executed` in opencode is for **slash commands** (e.g. `/clear`), not for bash tool calls — it fires at `session.idle` and never carries `name === "bash"`. The handler was wired to the wrong event.

## Fix

Bash tool completions surface as `EventMessagePartUpdated` with `part.type === "tool"` and `state.status === "completed"`. Move commit detection there as `handleToolResult(toolName, toolInput, sessionID, ctx)`, called from `handleMessagePartUpdated` when `success === true`.

- Match against both `command` and `description` fields of the bash tool input.
- Counter increments once per matching tool call (no double-count between fields).
- Removes the dead `handleCommandExecuted` handler, its switch case in `src/index.ts`, and the unused `EventCommandExecuted` import.

Strictly a bug fix — commits that previously went uncounted will now be counted.

---

Companion PR: #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated commit tracking detection to use tool result events instead of command execution events, improving event handling consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DEVtheOPS/opencode-plugin-otel/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->