### PR TITLE
fix: force-flush OTLP exporters on session.idle/session.error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,30 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
     await Promise.allSettled([meterProvider.shutdown(), loggerProvider.shutdown(), tracerProvider.shutdown()])
   }
 
+  /**
+   * Push every pending metric/log/span to the OTLP endpoint right away.
+   *
+   * Exporters are periodic (default 5s), so a session shorter than one
+   * interval would otherwise hold all its telemetry in memory when the
+   * host kills the process (e.g. the GitHub action kills `opencode serve`
+   * as soon as the chat returns). The SIGTERM/beforeExit handlers can't
+   * cover that case reliably — they start an async export the runtime may
+   * not wait for — so we flush while the process is still healthy.
+   */
+  async function flushAll(reason: string) {
+    const results = await Promise.allSettled([
+      meterProvider.forceFlush(),
+      loggerProvider.forceFlush(),
+      tracerProvider.forceFlush(),
+    ])
+    const failed = results.filter((r) => r.status === "rejected").length
+    if (failed > 0) {
+      await log("warn", "otel: flush incomplete", { reason, failed })
+    } else {
+      await log("debug", "otel: flushed", { reason })
+    }
+  }
+
   process.on("SIGTERM", () => { shutdown().then(() => process.exit(0)).catch(() => process.exit(1)) })
   process.on("SIGINT",  () => { shutdown().then(() => process.exit(0)).catch(() => process.exit(1)) })
   process.on("beforeExit", () => { shutdown().catch(() => {}) })
@@ -217,9 +241,13 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
           break
         case "session.idle":
           handleSessionIdle(event as EventSessionIdle, ctx)
+          // Sessions shorter than one export interval lose all telemetry
+          // if the host kills the process right after idle — flush now.
+          await flushAll("session.idle")
           break
         case "session.error":
           handleSessionError(event as EventSessionError, ctx)
+          await flushAll("session.error")
           break
         case "session.status":
           handleSessionStatus(event as EventSessionStatus, ctx)


### PR DESCRIPTION
## Problema
Los exporters son periódicos (5s por defecto). Una sesión más corta que un intervalo mantiene toda su telemetría en memoria, y el GitHub action mata `opencode serve` (`proc.kill()`) en cuanto el chat responde → **runs de CI de ~1s no exportan nada** (visto hoy en onesdata/atmos-mcp: run OK con qwen3-coder-next, cero datapoints en el portal). Los handlers SIGTERM/beforeExit no lo cubren: arrancan un export async que el runtime no espera antes de salir.

## Fix
`flushAll()` — `forceFlush()` de meter/logger/tracer providers — al recibir `session.idle` y `session.error`, con el proceso aún sano. Log `debug` en éxito, `warn` si algún provider falla.

## Validación
- `bun run typecheck` ✅
- `bun test` → 261 pass ✅
- `bun run lint` ✅

Tras merge: **publicar versión a npm** — el wrapper de ops_workflows consume `@devtheops/opencode-plugin-otel` sin pin, los runs cogerán la nueva versión automáticamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Enhanced telemetry data capture to ensure in-memory telemetry is properly transmitted during session termination. Application now flushes telemetry data when sessions become idle or encounter errors, reducing data loss for short-lived sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->