### PR TITLE
feat(config): allow plugin configuration via second options parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ src/
 - **All env vars are `OPENCODE_` prefixed** — `OPENCODE_ENABLE_TELEMETRY`, `OPENCODE_OTLP_ENDPOINT`, `OPENCODE_OTLP_METRICS_INTERVAL`, `OPENCODE_OTLP_LOGS_INTERVAL`, `OPENCODE_METRIC_PREFIX`, `OPENCODE_OTLP_HEADERS`, `OPENCODE_RESOURCE_ATTRIBUTES`, `OPENCODE_SPAN_ATTRIBUTES`. Never use bare `OTEL_*` names for plugin config. `loadConfig` copies `OPENCODE_OTLP_HEADERS` → `OTEL_EXPORTER_OTLP_HEADERS` and `OPENCODE_RESOURCE_ATTRIBUTES` → `OTEL_RESOURCE_ATTRIBUTES` before the SDK initializes.
 - **`OPENCODE_ENABLE_TELEMETRY`** — all OTel instrumentation is gated on this env var. The plugin always loads regardless; only telemetry is disabled when unset.
 - **`OPENCODE_METRIC_PREFIX`** — defaults to `opencode.`; set to `claude_code.` for Claude Code dashboard compatibility.
+- **Plugin options** — `loadConfig` also accepts an `OtelPluginOptions` object passed via opencode's plugin tuple form (`["opencode-plugin-otel", { ... }]`, threaded through `OtelPlugin`'s second argument). Precedence is option → `OPENCODE_*` env → default. Keep option keys 1:1 with `PluginConfig` field names.
 
 ## Commit message format
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Option keys mirror the resolved config and map to the environment variables:
 | `otlpHeaders` | `OPENCODE_OTLP_HEADERS` |
 | `otlpHeadersHelper` | `OPENCODE_OTLP_HEADERS_HELPER` |
 | `resourceAttributes` | `OPENCODE_RESOURCE_ATTRIBUTES` |
+| `spanAttributes` | `OPENCODE_SPAN_ATTRIBUTES` |
 | `traceparent` | `OPENCODE_TRACEPARENT` |
 | `tracestate` | `OPENCODE_TRACESTATE` |
 | `metricsTemporality` | `OPENCODE_OTLP_METRICS_TEMPORALITY` |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An [opencode](https://opencode.ai) plugin that exports telemetry via OpenTelemet
   - [Log events](#log-events)
 - [Installation](#installation)
 - [Configuration](#configuration)
+  - [Plugin options (opencode.json)](#plugin-options-opencodejson)
   - [Quick start](#quick-start)
   - [Headers and resource attributes](#headers-and-resource-attributes)
   - [Dynamic headers](#dynamic-headers)
@@ -84,7 +85,9 @@ Or point directly at a local checkout for development:
 
 ## Configuration
 
-All configuration is via environment variables. Set them in your shell profile (`~/.zshrc`, `~/.bashrc`, etc.).
+The plugin reads its settings from `OPENCODE_*` environment variables and/or from inline [plugin options](#plugin-options-opencodejson) in `opencode.json`. When both are present, an option wins over the matching environment variable, which wins over the built-in default.
+
+The environment variables (set them in your shell profile — `~/.zshrc`, `~/.bashrc`, etc.):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -104,6 +107,48 @@ All configuration is via environment variables. Set them in your shell profile (
 | `OPENCODE_OTLP_METRICS_TEMPORALITY` | *(unset)* | Metrics aggregation temporality: `delta`, `cumulative`, or `lowmemory`. Required for Datadog (`delta`). Copied to `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`. |
 | `OPENCODE_TRACEPARENT` | *(unset)* | W3C [`traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header) string. When set, all spans are parented under this remote context so opencode traces nest inside a caller's trace (e.g. a CI job). Invalid values are logged and ignored. Note: with the default `ParentBased` sampler, a value with the sampled flag off (`...-00`) suppresses all trace export. |
 | `OPENCODE_TRACESTATE` | *(unset)* | W3C [`tracestate`](https://www.w3.org/TR/trace-context/#tracestate-header) string, parsed alongside `OPENCODE_TRACEPARENT` and attached to the remote parent context. Ignored unless a valid `OPENCODE_TRACEPARENT` is also set. |
+
+### Plugin options (opencode.json)
+
+Every setting can also be passed inline through opencode's plugin **tuple form**, so nothing has to be exported in a shell. Options take precedence over the matching `OPENCODE_*` environment variable, which in turn wins over the built-in default.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    ["@devtheops/opencode-plugin-otel", {
+      "enabled": true,
+      "endpoint": "http://localhost:4317",
+      "protocol": "grpc",
+      "metricPrefix": "claude_code.",
+      "resourceAttributes": "service.version=1.2.3,deployment.environment=production",
+      "disabledTraces": ["tool"]
+    }]
+  ]
+}
+```
+
+Option keys mirror the resolved config and map to the environment variables:
+
+| Option | Environment variable |
+|--------|----------------------|
+| `enabled` | `OPENCODE_ENABLE_TELEMETRY` |
+| `logsEnabled` | `OPENCODE_DISABLE_LOGS` (inverted) |
+| `endpoint` | `OPENCODE_OTLP_ENDPOINT` |
+| `protocol` | `OPENCODE_OTLP_PROTOCOL` |
+| `metricsInterval` | `OPENCODE_OTLP_METRICS_INTERVAL` |
+| `logsInterval` | `OPENCODE_OTLP_LOGS_INTERVAL` |
+| `metricPrefix` | `OPENCODE_METRIC_PREFIX` |
+| `otlpHeaders` | `OPENCODE_OTLP_HEADERS` |
+| `otlpHeadersHelper` | `OPENCODE_OTLP_HEADERS_HELPER` |
+| `resourceAttributes` | `OPENCODE_RESOURCE_ATTRIBUTES` |
+| `traceparent` | `OPENCODE_TRACEPARENT` |
+| `tracestate` | `OPENCODE_TRACESTATE` |
+| `metricsTemporality` | `OPENCODE_OTLP_METRICS_TEMPORALITY` |
+| `disabledMetrics` | `OPENCODE_DISABLE_METRICS` (array, not a comma string) |
+| `disabledTraces` | `OPENCODE_DISABLE_TRACES` (array, not a comma string) |
+
+> **Security note:** `opencode.json` is frequently committed to version control. Keep secrets such as `otlpHeaders` in an environment variable or an opencode `{env:VAR}` substitution (e.g. `"otlpHeaders": "{env:OTEL_HEADERS}"`) rather than inline.
 
 ### Quick start
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,63 @@ export function parseAttributePairs(raw: string | undefined): Record<string, str
   return attrs
 }
 
+/**
+ * Options accepted via the opencode plugin tuple form
+ * (`["opencode-plugin-otel", { ... }]`). Every field is optional; a provided
+ * value takes precedence over the matching `OPENCODE_*` environment variable,
+ * which in turn wins over the built-in default. Field names mirror the resolved
+ * {@link PluginConfig}.
+ */
+export type OtelPluginOptions = {
+  enabled?: boolean
+  logsEnabled?: boolean
+  endpoint?: string
+  protocol?: "grpc" | "http/protobuf" | "http/json"
+  metricsInterval?: number
+  logsInterval?: number
+  metricPrefix?: string
+  otlpHeaders?: string
+  otlpHeadersHelper?: string
+  resourceAttributes?: string
+  spanAttributes?: string
+  traceparent?: string
+  tracestate?: string
+  metricsTemporality?: MetricsTemporality
+  disabledMetrics?: string[]
+  disabledTraces?: string[]
+}
+
+const VALID_PROTOCOLS = new Set<PluginConfig["protocol"]>(["grpc", "http/protobuf", "http/json"])
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function pickBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function pickPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined
+}
+
+function pickStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.filter((entry): entry is string => typeof entry === "string")
+}
+
+function pickProtocol(value: unknown): PluginConfig["protocol"] | undefined {
+  return typeof value === "string" && VALID_PROTOCOLS.has(value as PluginConfig["protocol"])
+    ? (value as PluginConfig["protocol"])
+    : undefined
+}
+
+function pickMetricsTemporality(value: unknown): MetricsTemporality | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.toLowerCase()
+  return VALID_TEMPORALITIES.has(normalized as MetricsTemporality) ? (normalized as MetricsTemporality) : undefined
+}
+
 /** Parses a positive integer from an environment variable, returning `fallback` if absent or invalid. */
 export function parseEnvInt(key: string, fallback: number): number {
   const raw = process.env[key]
@@ -59,75 +116,80 @@ function hasNonEmptyEnv(key: string): boolean {
   return !!process.env[key]
 }
 
-/** Parses `OPENCODE_DISABLE_TRACES`, expanding explicit global values like `all`. */
-function parseDisabledTraces(raw: string | undefined): Set<string> {
-  const values = (raw ?? "")
-    .split(",")
-    .map(s => s.trim().toLowerCase())
-    .filter(Boolean)
+function splitList(raw: string | undefined): string[] {
+  return (raw ?? "").split(",").map(s => s.trim()).filter(Boolean)
+}
 
-  if (values.some(value => TRACE_DISABLE_ALL_VALUES.has(value))) {
+function normalizeList(values: string[]): string[] {
+  return values.map(s => s.trim()).filter(Boolean)
+}
+
+/** Builds the disabled-traces set from raw values, expanding global values like `all` to every trace type. */
+function expandDisabledTraces(values: string[]): Set<string> {
+  const normalized = values.map(v => v.trim().toLowerCase()).filter(Boolean)
+  if (normalized.some(value => TRACE_DISABLE_ALL_VALUES.has(value))) {
     return new Set(TRACE_TYPES)
   }
-
-  return new Set(values)
+  return new Set(normalized)
 }
 
 /**
- * Reads all `OPENCODE_*` environment variables and returns the resolved plugin config.
- * Copies `OPENCODE_OTLP_HEADERS` → `OTEL_EXPORTER_OTLP_HEADERS`,
- * `OPENCODE_RESOURCE_ATTRIBUTES` → `OTEL_RESOURCE_ATTRIBUTES`, and
- * `OPENCODE_OTLP_METRICS_TEMPORALITY` → `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
- * so the OTel SDK picks them up automatically when initialised.
+ * Resolves the plugin config from plugin `options` and `OPENCODE_*` environment
+ * variables. For every field a provided option wins over the environment
+ * variable, which in turn wins over the built-in default.
+ *
+ * Copies the resolved headers, resource attributes, and metrics temporality into
+ * `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_RESOURCE_ATTRIBUTES`, and
+ * `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` so the OTel SDK picks them
+ * up automatically when initialised.
  */
-export function loadConfig(): PluginConfig {
-  const otlpHeaders = process.env["OPENCODE_OTLP_HEADERS"]
-  const otlpHeadersHelper = process.env["OPENCODE_OTLP_HEADERS_HELPER"]
-  const resourceAttributes = process.env["OPENCODE_RESOURCE_ATTRIBUTES"]
-  const spanAttributes = process.env["OPENCODE_SPAN_ATTRIBUTES"]
-  const traceparent = process.env["OPENCODE_TRACEPARENT"]
-  const tracestate = process.env["OPENCODE_TRACESTATE"]
-  const rawTemporality = process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
-  const protocol = process.env["OPENCODE_OTLP_PROTOCOL"]
+export function loadConfig(options: OtelPluginOptions = {}): PluginConfig {
+  const resolvedOptions = typeof options === "object" && options !== null ? options : {}
+  const otlpHeaders = pickString(resolvedOptions.otlpHeaders) ?? process.env["OPENCODE_OTLP_HEADERS"]
+  const otlpHeadersHelper = pickString(resolvedOptions.otlpHeadersHelper) ?? process.env["OPENCODE_OTLP_HEADERS_HELPER"]
+  const resourceAttributes = pickString(resolvedOptions.resourceAttributes) ?? process.env["OPENCODE_RESOURCE_ATTRIBUTES"]
+  const spanAttributes = pickString(resolvedOptions.spanAttributes) ?? process.env["OPENCODE_SPAN_ATTRIBUTES"]
+  const traceparent = pickString(resolvedOptions.traceparent) ?? process.env["OPENCODE_TRACEPARENT"]
+  const tracestate = pickString(resolvedOptions.tracestate) ?? process.env["OPENCODE_TRACESTATE"]
+  const optionMetricsTemporality = pickMetricsTemporality(resolvedOptions.metricsTemporality)
+  const envMetricsTemporality = pickMetricsTemporality(process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"])
+  const metricsTemporality = optionMetricsTemporality ?? envMetricsTemporality
+  const protocol = pickProtocol(resolvedOptions.protocol)
+    ?? pickProtocol(process.env["OPENCODE_OTLP_PROTOCOL"])
+    ?? "grpc"
 
-  let metricsTemporality: MetricsTemporality | undefined
-  if (rawTemporality) {
-    const normalized = rawTemporality.toLowerCase()
-    if (VALID_TEMPORALITIES.has(normalized as MetricsTemporality)) {
-      metricsTemporality = normalized as MetricsTemporality
-      process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = normalized
-    } else {
-      console.warn(
-        `[opencode-plugin-otel] Invalid OPENCODE_OTLP_METRICS_TEMPORALITY="${rawTemporality}". ` +
-          `Expected one of: cumulative, delta, lowmemory. Value ignored.`,
-      )
-    }
+  if (
+    optionMetricsTemporality === undefined
+    && envMetricsTemporality === undefined
+    && pickString(process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"])
+  ) {
+    console.warn(
+      `[opencode-plugin-otel] Invalid metrics temporality "${process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]}". ` +
+        `Expected one of: cumulative, delta, lowmemory. Value ignored.`,
+    )
   }
+
+  if (metricsTemporality) process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = metricsTemporality
 
   if (otlpHeaders) process.env["OTEL_EXPORTER_OTLP_HEADERS"] = otlpHeaders
   if (resourceAttributes) process.env["OTEL_RESOURCE_ATTRIBUTES"] = resourceAttributes
 
+  const optionMetrics = pickStringList(resolvedOptions.disabledMetrics)
   const disabledMetrics = new Set(
-    (process.env["OPENCODE_DISABLE_METRICS"] ?? "")
-      .split(",")
-      .map(s => s.trim())
-      .filter(Boolean),
+    optionMetrics ? normalizeList(optionMetrics) : splitList(process.env["OPENCODE_DISABLE_METRICS"]),
   )
 
-  const disabledTraces = parseDisabledTraces(process.env["OPENCODE_DISABLE_TRACES"])
+  const optionTraces = pickStringList(resolvedOptions.disabledTraces)
+  const disabledTraces = expandDisabledTraces(optionTraces ?? splitList(process.env["OPENCODE_DISABLE_TRACES"]))
 
   return {
-    enabled: hasNonEmptyEnv("OPENCODE_ENABLE_TELEMETRY"),
-    logsEnabled: !hasNonEmptyEnv("OPENCODE_DISABLE_LOGS"),
-    endpoint: process.env["OPENCODE_OTLP_ENDPOINT"] ?? "http://localhost:4317",
-    protocol: protocol === "http/protobuf"
-      ? "http/protobuf"
-      : protocol === "http/json"
-        ? "http/json"
-        : "grpc",
-    metricsInterval: parseEnvInt("OPENCODE_OTLP_METRICS_INTERVAL", 60000),
-    logsInterval: parseEnvInt("OPENCODE_OTLP_LOGS_INTERVAL", 5000),
-    metricPrefix: process.env["OPENCODE_METRIC_PREFIX"] ?? "opencode.",
+    enabled: pickBoolean(resolvedOptions.enabled) ?? hasNonEmptyEnv("OPENCODE_ENABLE_TELEMETRY"),
+    logsEnabled: pickBoolean(resolvedOptions.logsEnabled) ?? !hasNonEmptyEnv("OPENCODE_DISABLE_LOGS"),
+    endpoint: pickString(resolvedOptions.endpoint) ?? process.env["OPENCODE_OTLP_ENDPOINT"] ?? "http://localhost:4317",
+    protocol,
+    metricsInterval: pickPositiveInt(resolvedOptions.metricsInterval) ?? parseEnvInt("OPENCODE_OTLP_METRICS_INTERVAL", 60000),
+    logsInterval: pickPositiveInt(resolvedOptions.logsInterval) ?? parseEnvInt("OPENCODE_OTLP_LOGS_INTERVAL", 5000),
+    metricPrefix: pickString(resolvedOptions.metricPrefix) ?? process.env["OPENCODE_METRIC_PREFIX"] ?? "opencode.",
     otlpHeaders,
     otlpHeadersHelper,
     resourceAttributes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import type {
   EventCommandExecuted,
 } from "@opencode-ai/sdk"
 import { LEVELS, type Level, type HandlerContext } from "./types.ts"
-import { loadConfig, parseAttributePairs, resolveHelperPath, resolveLogLevel } from "./config.ts"
+import { loadConfig, parseAttributePairs, resolveHelperPath, resolveLogLevel, type OtelPluginOptions } from "./config.ts"
 import { probeEndpoint } from "./probe.ts"
 import { setupOtel, createInstruments, forceFlushOtel } from "./otel.ts"
 import { remoteParentContext } from "./trace-context.ts"
@@ -35,8 +35,8 @@ const PLUGIN_VERSION: string = (pkg as { version?: string }).version ?? "unknown
  * Instruments metrics (sessions, tokens, cost, lines of code, commits, tool durations)
  * and structured log events. All instrumentation is gated on `OPENCODE_ENABLE_TELEMETRY`.
  */
-export const OtelPlugin: Plugin = async ({ project, client, directory, worktree }) => {
-  const config = loadConfig()
+export const OtelPlugin: Plugin = async ({ project, client, directory, worktree }, options) => {
+  const config = loadConfig(options as OtelPluginOptions)
   const otlpHeadersHelper = resolveHelperPath(config.otlpHeadersHelper, directory, worktree)
   let minLevel: Level = "info"
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -327,6 +327,121 @@ describe("loadConfig", () => {
   })
 })
 
+describe("loadConfig options", () => {
+  const vars = [
+    "OPENCODE_ENABLE_TELEMETRY",
+    "OPENCODE_OTLP_ENDPOINT",
+    "OPENCODE_OTLP_PROTOCOL",
+    "OPENCODE_OTLP_METRICS_INTERVAL",
+    "OPENCODE_OTLP_LOGS_INTERVAL",
+    "OPENCODE_METRIC_PREFIX",
+    "OPENCODE_OTLP_HEADERS",
+    "OPENCODE_RESOURCE_ATTRIBUTES",
+    "OPENCODE_OTLP_METRICS_TEMPORALITY",
+    "OPENCODE_DISABLE_METRICS",
+    "OPENCODE_DISABLE_LOGS",
+    "OPENCODE_DISABLE_TRACES",
+    "OTEL_EXPORTER_OTLP_HEADERS",
+    "OTEL_RESOURCE_ATTRIBUTES",
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+  ]
+  beforeEach(() => vars.forEach((k) => delete process.env[k]))
+  afterEach(() => vars.forEach((k) => delete process.env[k]))
+
+  test("enabled via option without any env var", () => {
+    expect(loadConfig({ enabled: true }).enabled).toBe(true)
+  })
+
+  test("option enabled:false overrides an enabling env var", () => {
+    process.env["OPENCODE_ENABLE_TELEMETRY"] = "1"
+    expect(loadConfig({ enabled: false }).enabled).toBe(false)
+  })
+
+  test("option logsEnabled:false disables logs", () => {
+    expect(loadConfig({ logsEnabled: false }).logsEnabled).toBe(false)
+  })
+
+  test("option endpoint overrides env var", () => {
+    process.env["OPENCODE_OTLP_ENDPOINT"] = "http://from-env:4317"
+    expect(loadConfig({ endpoint: "http://from-option:4317" }).endpoint).toBe("http://from-option:4317")
+  })
+
+  test("env endpoint used when option is absent", () => {
+    process.env["OPENCODE_OTLP_ENDPOINT"] = "http://from-env:4317"
+    expect(loadConfig({ metricPrefix: "x." }).endpoint).toBe("http://from-env:4317")
+  })
+
+  test("option protocol overrides env var", () => {
+    process.env["OPENCODE_OTLP_PROTOCOL"] = "grpc"
+    expect(loadConfig({ protocol: "http/protobuf" }).protocol).toBe("http/protobuf")
+  })
+
+  test("option intervals override env vars", () => {
+    process.env["OPENCODE_OTLP_METRICS_INTERVAL"] = "30000"
+    const cfg = loadConfig({ metricsInterval: 15000, logsInterval: 2500 })
+    expect(cfg.metricsInterval).toBe(15000)
+    expect(cfg.logsInterval).toBe(2500)
+  })
+
+  test("invalid option interval falls back to env then default", () => {
+    process.env["OPENCODE_OTLP_METRICS_INTERVAL"] = "45000"
+    const cfg = loadConfig({ metricsInterval: 0, logsInterval: -1 })
+    expect(cfg.metricsInterval).toBe(45000)
+    expect(cfg.logsInterval).toBe(5000)
+  })
+
+  test("non-number option interval is ignored", () => {
+    const cfg = loadConfig({ metricsInterval: "soon" } as unknown as Parameters<typeof loadConfig>[0])
+    expect(cfg.metricsInterval).toBe(60000)
+  })
+
+  test("option metricPrefix overrides env var", () => {
+    process.env["OPENCODE_METRIC_PREFIX"] = "env."
+    expect(loadConfig({ metricPrefix: "claude_code." }).metricPrefix).toBe("claude_code.")
+  })
+
+  test("option otlpHeaders is copied to OTEL_EXPORTER_OTLP_HEADERS", () => {
+    const cfg = loadConfig({ otlpHeaders: "api-key=opt" })
+    expect(cfg.otlpHeaders).toBe("api-key=opt")
+    expect(process.env["OTEL_EXPORTER_OTLP_HEADERS"]).toBe("api-key=opt")
+  })
+
+  test("option resourceAttributes is copied to OTEL_RESOURCE_ATTRIBUTES", () => {
+    const cfg = loadConfig({ resourceAttributes: "team=platform" })
+    expect(cfg.resourceAttributes).toBe("team=platform")
+    expect(process.env["OTEL_RESOURCE_ATTRIBUTES"]).toBe("team=platform")
+  })
+
+  test("option metricsTemporality is normalized and copied to OTEL preference", () => {
+    const cfg = loadConfig({ metricsTemporality: "delta" })
+    expect(cfg.metricsTemporality).toBe("delta")
+    expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBe("delta")
+  })
+
+  test("option disabledMetrics array overrides env var", () => {
+    process.env["OPENCODE_DISABLE_METRICS"] = "session.count"
+    const { disabledMetrics } = loadConfig({ disabledMetrics: ["cache.count", "retry.count"] })
+    expect(disabledMetrics).toEqual(new Set(["cache.count", "retry.count"]))
+  })
+
+  test("option disabledTraces array expands all to every trace type", () => {
+    expect(loadConfig({ disabledTraces: ["all"] }).disabledTraces).toEqual(new Set(TRACE_TYPES))
+  })
+
+  test("option disabledTraces array trims and lowercases entries", () => {
+    const { disabledTraces } = loadConfig({ disabledTraces: [" LLM ", "Tool"] })
+    expect(disabledTraces).toEqual(new Set(["llm", "tool"]))
+  })
+
+  test("env values still apply when no options are passed", () => {
+    process.env["OPENCODE_ENABLE_TELEMETRY"] = "1"
+    process.env["OPENCODE_OTLP_ENDPOINT"] = "http://env:4317"
+    const cfg = loadConfig()
+    expect(cfg.enabled).toBe(true)
+    expect(cfg.endpoint).toBe("http://env:4317")
+  })
+})
+
 describe("resolveLogLevel", () => {
   test("resolves known level (uppercase input)", () => {
     expect(resolveLogLevel("DEBUG", "info")).toBe("debug")

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -395,6 +395,11 @@ describe("loadConfig options", () => {
     expect(cfg.metricsInterval).toBe(60000)
   })
 
+  test("null options are handled safely", () => {
+    expect(() => loadConfig(null as unknown as Parameters<typeof loadConfig>[0])).not.toThrow()
+    expect(loadConfig(null as unknown as Parameters<typeof loadConfig>[0]).endpoint).toBe("http://localhost:4317")
+  })
+
   test("option metricPrefix overrides env var", () => {
     process.env["OPENCODE_METRIC_PREFIX"] = "env."
     expect(loadConfig({ metricPrefix: "claude_code." }).metricPrefix).toBe("claude_code.")
@@ -416,6 +421,20 @@ describe("loadConfig options", () => {
     const cfg = loadConfig({ metricsTemporality: "delta" })
     expect(cfg.metricsTemporality).toBe("delta")
     expect(process.env["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"]).toBe("delta")
+  })
+
+  test("invalid protocol option falls back to env then default", () => {
+    process.env["OPENCODE_OTLP_PROTOCOL"] = "http/json"
+    expect(loadConfig({ protocol: "ftp" as never }).protocol).toBe("http/json")
+    delete process.env["OPENCODE_OTLP_PROTOCOL"]
+    expect(loadConfig({ protocol: "ftp" as never }).protocol).toBe("grpc")
+  })
+
+  test("invalid metricsTemporality option falls back to env then default", () => {
+    process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"] = "lowmemory"
+    expect(loadConfig({ metricsTemporality: "weekly" as never }).metricsTemporality).toBe("lowmemory")
+    delete process.env["OPENCODE_OTLP_METRICS_TEMPORALITY"]
+    expect(loadConfig({ metricsTemporality: "weekly" as never }).metricsTemporality).toBeUndefined()
   })
 
   test("option disabledMetrics array overrides env var", () => {


### PR DESCRIPTION
## Description

[Since March 2026](https://github.com/anomalyco/opencode/pull/19347), Opencode has supported passing options to plugins as a second parameter. This change allows resolving plugin configuration from opencode's plugin tuple form `(["opencode-plugin-otel", { ... }]) `in addition to `OPENCODE_*` env vars. Precedence is option > env > default, so existing env-only setups are unchanged and `loadConfig()` still works with no arguments.

loadConfig now accepts an `OtelPluginOptions` object (keys 1:1 with PluginConfig) and validates every field at runtime, so malformed JSON options fall through to env/default. The entrypoint threads opencode's second factory argument through to loadConfig.

## Type of change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependency updates, etc.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project (I hope so; if not, please point out what should be different)
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

none

## Additional context

none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline OTEL plugin options via `opencode.json` tuple syntax, which override matching environment variables and built-in defaults.
  * Option-based configuration now drives endpoint/protocol, enablement, intervals, OTLP headers and resource attributes, metrics temporality, and disabled metrics/traces (including `all` expansion for trace types).

* **Documentation**
  * Updated README and AGENTS.md with tuple examples, precedence rules, option-to-env mappings, data-shape notes, and a security reminder to avoid sensitive inline values.

* **Tests**
  * Expanded coverage for option precedence, validation/fallback behavior (including invalid inputs), environment propagation, and safe handling of `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->