### PR TITLE
feat(telemetry): add skill usage telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ An [opencode](https://opencode.ai) plugin that exports telemetry via OpenTelemet
 | `opencode.session.cost.total` | Histogram | Total cost per session in USD, recorded on idle |
 | `opencode.model.usage` | Counter | Messages per model and provider |
 | `opencode.retry.count` | Counter | API retries observed via `session.status` events |
+| `opencode.skill.count` | Counter | Skill invocations observed through command aliases or the native skill tool |
 
 ### Log events
 
@@ -60,6 +61,7 @@ An [opencode](https://opencode.ai) plugin that exports telemetry via OpenTelemet
 | `api_error` | Failed assistant message (error summary, duration) |
 | `tool_result` | Tool completed or errored (duration, success, output size) |
 | `tool_decision` | Permission prompt answered (accept/reject) |
+| `skill_invoked` | Skill invoked (includes skill name, invocation type, command or tool name, optional agent/subtask metadata, and command argument length when available) |
 | `commit` | Git commit detected |
 
 ## Installation
@@ -165,7 +167,7 @@ Disabling a metric only stops the counter/histogram from being incremented — t
 export OPENCODE_DISABLE_METRICS="retry.count"
 
 # Disable multiple metrics
-export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.total,session.cost.total,model.usage,retry.count,message.count"
+export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.total,session.cost.total,model.usage,retry.count,message.count,skill.count"
 
 # Disable the new per-session cumulative gauge while keeping the delta counter
 export OPENCODE_DISABLE_METRICS="lines_of_code.total"
@@ -176,7 +178,7 @@ export OPENCODE_DISABLE_METRICS="lines_of_code.total"
 The following metrics are specific to opencode and have no equivalent in Claude Code's built-in monitoring. If you are using a Claude Code dashboard and want to avoid cluttering it with opencode-only metrics, you can disable them:
 
 ```bash
-export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.total,session.cost.total,model.usage,retry.count,message.count"
+export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.total,session.cost.total,model.usage,retry.count,message.count,skill.count"
 ```
 
 | Metric suffix | Why it's opencode-only |
@@ -188,6 +190,7 @@ export OPENCODE_DISABLE_METRICS="cache.count,session.duration,session.token.tota
 | `model.usage` | Per-model message counter — not emitted by Claude Code |
 | `retry.count` | API retry counter — not emitted by Claude Code |
 | `message.count` | Completed message counter — not emitted by Claude Code |
+| `skill.count` | OpenCode skill usage counter — not emitted by Claude Code |
 
 ### Disabling OTLP logs
 

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -29,6 +29,7 @@ import {
 } from "@arizeai/openinference-semantic-conventions"
 import { errorSummary, setBoundedMap, accumulateSessionTotals, isMetricEnabled, isTraceEnabled } from "../util.ts"
 import type { HandlerContext } from "../types.ts"
+import { recordSkillInvocation, skillNameFromToolInput } from "./skill.ts"
 
 const OPENINFERENCE_SPAN_KIND = SemanticConventions.OPENINFERENCE_SPAN_KIND
 const LLM_FINISH_REASON = "llm.finish_reason"
@@ -251,8 +252,17 @@ export function handleMessagePartUpdated(e: EventMessagePartUpdated, ctx: Handle
   if (part.type === "tool") {
     const toolPart = part as ToolPart
     const key = `${toolPart.sessionID}:${toolPart.callID}`
+    const isSkillTool = toolPart.tool === "skill"
 
     if (toolPart.state.status === "running") {
+      if (isSkillTool && !ctx.pendingToolSpans.has(key)) {
+        recordSkillInvocation({
+          sessionID: toolPart.sessionID,
+          skillName: skillNameFromToolInput(toolPart.state.input),
+          invocationType: "tool",
+          toolName: toolPart.tool,
+        }, ctx)
+      }
       const toolSpan = isTraceEnabled("tool", ctx)
         ? (() => {
             const sessionSpan = ctx.sessionSpans.get(toolPart.sessionID)
@@ -294,6 +304,14 @@ export function handleMessagePartUpdated(e: EventMessagePartUpdated, ctx: Handle
 
     const pending = ctx.pendingToolSpans.get(key)
     ctx.pendingToolSpans.delete(key)
+    if (isSkillTool && !pending) {
+      recordSkillInvocation({
+        sessionID: toolPart.sessionID,
+        skillName: skillNameFromToolInput(toolPart.state.input),
+        invocationType: "tool",
+        toolName: toolPart.tool,
+      }, ctx)
+    }
     const start = pending?.startMs ?? toolPart.state.time.start
     const end = toolPart.state.time.end
     if (end === undefined) return

--- a/src/handlers/skill.ts
+++ b/src/handlers/skill.ts
@@ -1,0 +1,267 @@
+import { isMetricEnabled } from "../util.ts"
+import type { HandlerContext, PluginLogger } from "../types.ts"
+
+type SkillCommandInfo = {
+  name: string
+  description?: string
+  agent?: string
+  subtask?: boolean
+}
+
+type RawCommand = {
+  name?: unknown
+  source?: unknown
+  description?: unknown
+  agent?: unknown
+  subtask?: unknown
+}
+
+type CommandListClient = {
+  command?: {
+    list(options?: { query?: { directory?: string; workspace?: string } }): Promise<{ data?: unknown; error?: unknown } | unknown>
+  }
+}
+
+type CommandExecuteInput = {
+  command: string
+  sessionID: string
+  arguments: string
+}
+
+type SkillInvocationInput = {
+  sessionID: string
+  skillName: string
+  invocationType: "command" | "tool"
+  commandName?: string
+  toolName?: string
+  argumentsLength?: number
+  description?: string
+  agent?: string
+  subtask?: boolean
+}
+
+type SkillCommandLookup = {
+  ok: boolean
+  commands: SkillCommandInfo[]
+}
+
+type ParsedSkillCommands = {
+  sourceAware: boolean
+  commands: SkillCommandInfo[]
+}
+
+function rawSkillCommand(command: RawCommand): SkillCommandInfo | undefined {
+  if (command.source !== "skill" || typeof command.name !== "string") return undefined
+  return {
+    name: command.name,
+    ...(typeof command.description === "string" ? { description: command.description } : {}),
+    ...(typeof command.agent === "string" ? { agent: command.agent } : {}),
+    ...(typeof command.subtask === "boolean" ? { subtask: command.subtask } : {}),
+  }
+}
+
+function commandsFromPayload(payload: unknown): ParsedSkillCommands {
+  const data = payload && typeof payload === "object" && "data" in payload
+    ? (payload as { data?: unknown }).data
+    : payload
+  const commands = data && typeof data === "object" && "data" in data
+    ? (data as { data?: unknown }).data
+    : data
+  if (!Array.isArray(commands)) return { sourceAware: false, commands: [] }
+  return {
+    sourceAware: commands.length === 0
+      || commands.some((command) => command && typeof command === "object" && "source" in command),
+    commands: commands
+      .map((command) => rawSkillCommand(command as RawCommand))
+      .filter((command): command is SkillCommandInfo => !!command),
+  }
+}
+
+async function clientSkillCommands(client: CommandListClient, directory: string | undefined): Promise<SkillCommandLookup> {
+  if (!client.command?.list) return { ok: false, commands: [] }
+  const response = await client.command.list(directory ? { query: { directory } } : undefined)
+  if (response && typeof response === "object" && "error" in response && (response as { error?: unknown }).error !== undefined) {
+    return { ok: false, commands: [] }
+  }
+  const parsed = commandsFromPayload(response)
+  return { ok: parsed.sourceAware, commands: parsed.commands }
+}
+
+async function rawSkillCommands(serverUrl: URL, directory: string | undefined, path: "/command" | "/api/command"): Promise<SkillCommandLookup> {
+  const url = new URL(path, serverUrl)
+  if (directory) {
+    if (path === "/api/command") {
+      url.searchParams.set("location[directory]", directory)
+    } else {
+      url.searchParams.set("directory", directory)
+    }
+  }
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 1_000)
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) return { ok: false, commands: [] }
+    const parsed = commandsFromPayload(await response.json())
+    return { ok: parsed.sourceAware, commands: parsed.commands }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function createSkillCommandResolver(input: {
+  client: CommandListClient
+  serverUrl: URL
+  directory?: string
+  log: PluginLogger
+}) {
+  let lastRefresh = 0
+  let refreshPromise: Promise<void> | undefined
+  const skillCommands = new Map<string, SkillCommandInfo>()
+
+  const refresh = async (force = false) => {
+    if (!force && Date.now() - lastRefresh < 30_000) return
+    if (refreshPromise) return refreshPromise
+    refreshPromise = (async () => {
+      const next = new Map<string, SkillCommandInfo>()
+      let catalogLoaded = false
+      try {
+        const lookup = await clientSkillCommands(input.client, input.directory)
+        catalogLoaded = catalogLoaded || lookup.ok
+        for (const command of lookup.commands) {
+          next.set(command.name, command)
+        }
+      } catch (err) {
+        await input.log("debug", "otel: command catalog lookup failed", {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      if (next.size === 0) {
+        try {
+          const lookup = await rawSkillCommands(input.serverUrl, input.directory, "/command")
+          catalogLoaded = catalogLoaded || lookup.ok
+          for (const command of lookup.commands) {
+            next.set(command.name, command)
+          }
+        } catch (err) {
+          await input.log("debug", "otel: raw command catalog lookup failed", {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+      if (next.size === 0) {
+        try {
+          const lookup = await rawSkillCommands(input.serverUrl, input.directory, "/api/command")
+          catalogLoaded = catalogLoaded || lookup.ok
+          for (const command of lookup.commands) {
+            next.set(command.name, command)
+          }
+        } catch (err) {
+          await input.log("debug", "otel: v2 command catalog lookup failed", {
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+      if (!catalogLoaded) {
+        await input.log("debug", "otel: skill command catalog refresh skipped")
+        return
+      }
+      skillCommands.clear()
+      for (const [name, command] of next) skillCommands.set(name, command)
+      lastRefresh = Date.now()
+      await input.log("debug", "otel: skill command catalog refreshed", { count: skillCommands.size })
+    })().finally(() => {
+      refreshPromise = undefined
+    })
+    return refreshPromise
+  }
+
+  return {
+    refresh,
+    resolve: async (command: string) => {
+      let skill = skillCommands.get(command)
+      if (skill) return skill
+      await refresh(false)
+      skill = skillCommands.get(command)
+      return skill
+    },
+  }
+}
+
+function stringProp(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key]
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+/** Extracts a skill name from the native `skill` tool input without exposing raw input. */
+export function skillNameFromToolInput(input: unknown): string {
+  if (typeof input === "string" && input.trim()) return input
+  if (!input || typeof input !== "object") return "unknown"
+  const record = input as Record<string, unknown>
+  const direct = stringProp(record, "skill") ?? stringProp(record, "skillName") ?? stringProp(record, "name")
+  if (direct) return direct
+  const skill = record.skill
+  if (skill && typeof skill === "object") {
+    return stringProp(skill as Record<string, unknown>, "name") ?? "unknown"
+  }
+  return "unknown"
+}
+
+/** Emits the shared skill usage metric and log event for command and native tool paths. */
+export function recordSkillInvocation(input: SkillInvocationInput, ctx: HandlerContext) {
+  const attrs = {
+    ...ctx.commonAttrs,
+    "session.id": input.sessionID,
+    skill_name: input.skillName,
+    invocation_type: input.invocationType,
+    ...(input.commandName ? { command_name: input.commandName } : {}),
+    ...(input.toolName ? { tool_name: input.toolName } : {}),
+    ...(input.agent ? { agent: input.agent } : {}),
+    ...(input.subtask !== undefined ? { subtask: input.subtask } : {}),
+  }
+
+  if (isMetricEnabled("skill.count", ctx)) {
+    ctx.instruments.skillCounter.add(1, attrs)
+  }
+
+  ctx.emitLog({
+    severityNumber: ctx.logSeverity.info,
+    severityText: "INFO",
+    timestamp: Date.now(),
+    observedTimestamp: Date.now(),
+    body: "skill_invoked",
+    attributes: {
+      "event.name": "skill_invoked",
+      ...attrs,
+      ...(input.argumentsLength !== undefined ? { arguments_length: input.argumentsLength } : {}),
+      ...(input.description ? { description: input.description } : {}),
+    },
+  })
+
+  return ctx.log("info", "otel: skill_invoked", {
+    sessionID: input.sessionID,
+    skill_name: input.skillName,
+    invocation_type: input.invocationType,
+    ...(input.commandName ? { command_name: input.commandName } : {}),
+    ...(input.toolName ? { tool_name: input.toolName } : {}),
+  })
+}
+
+export async function handleCommandExecuteBefore(
+  input: CommandExecuteInput,
+  ctx: HandlerContext,
+  resolveSkillCommand: (command: string) => Promise<SkillCommandInfo | undefined>,
+) {
+  const skill = await resolveSkillCommand(input.command)
+  if (!skill) return
+
+  return recordSkillInvocation({
+    sessionID: input.sessionID,
+    skillName: skill.name,
+    invocationType: "command",
+    commandName: input.command,
+    argumentsLength: input.arguments.length,
+    ...(skill.description ? { description: skill.description } : {}),
+    ...(skill.agent ? { agent: skill.agent } : {}),
+    ...(skill.subtask !== undefined ? { subtask: skill.subtask } : {}),
+  }, ctx)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSess
 import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "./handlers/message.ts"
 import { handlePermissionUpdated, handlePermissionReplied } from "./handlers/permission.ts"
 import { handleSessionDiff, handleCommandExecuted } from "./handlers/activity.ts"
+import { createSkillCommandResolver, handleCommandExecuteBefore } from "./handlers/skill.ts"
 
 const PLUGIN_VERSION: string = (pkg as { version?: string }).version ?? "unknown"
 
@@ -33,7 +34,7 @@ const PLUGIN_VERSION: string = (pkg as { version?: string }).version ?? "unknown
  * Instruments metrics (sessions, tokens, cost, lines of code, commits, tool durations)
  * and structured log events. All instrumentation is gated on `OPENCODE_ENABLE_TELEMETRY`.
  */
-export const OtelPlugin: Plugin = async ({ project, client, directory, worktree }) => {
+export const OtelPlugin: Plugin = async ({ project, client, directory, worktree, serverUrl }) => {
   const config = loadConfig()
   const otlpHeadersHelper = resolveHelperPath(config.otlpHeadersHelper, directory, worktree)
   let minLevel: Level = "info"
@@ -123,6 +124,7 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
   const ctx: HandlerContext = {
     log,
     emitLog,
+    logSeverity: { info: SeverityNumber.INFO, error: SeverityNumber.ERROR },
     instruments,
     commonAttrs,
     pendingToolSpans,
@@ -139,6 +141,8 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
     sessionInputs,
     messageOutputs,
   }
+  const skillCommands = createSkillCommandResolver({ client, serverUrl, directory, log })
+  await skillCommands.refresh(true)
 
   async function shutdown() {
     await Promise.allSettled([meterProvider.shutdown(), loggerProvider.shutdown(), tracerProvider.shutdown()])
@@ -215,6 +219,10 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
           ...commonAttrs,
         },
       })
+    }),
+
+    "command.execute.before": safe("command.execute.before", async (input) => {
+      await handleCommandExecuteBefore(input, ctx, skillCommands.resolve)
     }),
 
     event: safe("event", async ({ event }) => {

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -209,5 +209,9 @@ export function createInstruments(prefix: string): Instruments {
       unit: "{subtask}",
       description: "Number of sub-agent invocations observed via subtask message parts",
     }),
+    skillCounter: meter.createCounter(`${prefix}skill.count`, {
+      unit: "{skill}",
+      description: "Number of skill invocations observed via command execution and native skill tool hooks",
+    }),
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,12 @@ export type PluginLogger = (
 /** OTel resource attributes common to every emitted log and metric. */
 export type CommonAttrs = { readonly "project.id": string }
 
+/** Severity numbers supplied by the plugin entrypoint so handlers do not import log globals. */
+export type LogSeverity = {
+  info: NonNullable<LogRecord["severityNumber"]>
+  error: NonNullable<LogRecord["severityNumber"]>
+}
+
 /** In-flight tool execution tracked between `running` and `completed`/`error` part updates. */
 export type PendingToolSpan = {
   tool: string
@@ -52,6 +58,7 @@ export type Instruments = {
   modelUsageCounter: Counter
   retryCounter: Counter
   subtaskCounter: Counter
+  skillCounter: Counter
 }
 
 /** Accumulated per-session totals used for gauge snapshots on session.idle. */
@@ -67,6 +74,7 @@ export type SessionTotals = {
 export type HandlerContext = {
   log: PluginLogger
   emitLog: (record: LogRecord) => void
+  logSeverity: LogSeverity
   instruments: Instruments
   commonAttrs: CommonAttrs
   pendingToolSpans: Map<string, PendingToolSpan>

--- a/tests/handlers/disabled-metrics.test.ts
+++ b/tests/handlers/disabled-metrics.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test"
 import { handleSessionCreated, handleSessionIdle, handleSessionStatus } from "../../src/handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated } from "../../src/handlers/message.ts"
 import { handleSessionDiff, handleCommandExecuted } from "../../src/handlers/activity.ts"
+import { handleCommandExecuteBefore } from "../../src/handlers/skill.ts"
 import { makeCtx } from "../helpers.ts"
 import type { EventSessionCreated, EventSessionIdle, EventSessionStatus, EventMessageUpdated, EventMessagePartUpdated, EventSessionDiff, EventCommandExecuted } from "@opencode-ai/sdk"
 
@@ -226,13 +227,35 @@ describe("OPENCODE_DISABLE_METRICS", () => {
     })
   })
 
+  describe("skill.count disabled", () => {
+    test("does not increment skill counter", async () => {
+      const { ctx, counters } = makeCtx("proj_test", ["skill.count"])
+      await handleCommandExecuteBefore(
+        { command: "review", sessionID: "ses_1", arguments: "args" },
+        ctx,
+        async () => ({ name: "review" }),
+      )
+      expect(counters.skill.calls).toHaveLength(0)
+    })
+
+    test("still emits skill_invoked log record", async () => {
+      const { ctx, logger } = makeCtx("proj_test", ["skill.count"])
+      await handleCommandExecuteBefore(
+        { command: "review", sessionID: "ses_1", arguments: "args" },
+        ctx,
+        async () => ({ name: "review" }),
+      )
+      expect(logger.records.some((record) => record.body === "skill_invoked")).toBe(true)
+    })
+  })
+
   describe("multiple disabled at once", () => {
     test("disabling all metrics stops all counter/histogram calls", async () => {
       const all = [
         "session.count", "token.usage", "cost.usage", "lines_of_code.count",
         "commit.count", "tool.duration", "cache.count", "session.duration",
         "message.count", "session.token.total", "session.cost.total",
-        "model.usage", "retry.count", "subtask.count",
+        "model.usage", "retry.count", "subtask.count", "skill.count",
       ]
       const { ctx, counters, histograms, gauges } = makeCtx("proj_test", all)
       const subtaskEvent = {
@@ -251,6 +274,11 @@ describe("OPENCODE_DISABLE_METRICS", () => {
       await handleMessagePartUpdated(makeToolPart("running"), ctx)
       await handleMessagePartUpdated(makeToolPart("completed"), ctx)
       await handleMessagePartUpdated(subtaskEvent, ctx)
+      await handleCommandExecuteBefore(
+        { command: "review", sessionID: "ses_1", arguments: "args" },
+        ctx,
+        async () => ({ name: "review" }),
+      )
 
       expect(counters.session.calls).toHaveLength(0)
       expect(counters.token.calls).toHaveLength(0)
@@ -262,6 +290,7 @@ describe("OPENCODE_DISABLE_METRICS", () => {
       expect(counters.lines.calls).toHaveLength(0)
       expect(counters.commit.calls).toHaveLength(0)
       expect(counters.subtask.calls).toHaveLength(0)
+      expect(counters.skill.calls).toHaveLength(0)
       expect(histograms.tool.calls).toHaveLength(0)
       expect(histograms.sessionDuration.calls).toHaveLength(0)
       expect(gauges.sessionToken.calls).toHaveLength(0)

--- a/tests/handlers/message.test.ts
+++ b/tests/handlers/message.test.ts
@@ -83,7 +83,7 @@ function makeIncompleteAssistantMessage(): EventMessageUpdated {
 
 function makeToolPartUpdated(
   status: "running" | "completed" | "error",
-  overrides: { sessionID?: string; callID?: string; tool?: string; startMs?: number; endMs?: number } = {},
+  overrides: { sessionID?: string; callID?: string; tool?: string; startMs?: number; endMs?: number; input?: unknown } = {},
 ): EventMessagePartUpdated {
   const sessionID = overrides.sessionID ?? "ses_1"
   const callID = overrides.callID ?? "call_1"
@@ -92,10 +92,10 @@ function makeToolPartUpdated(
 
   const state =
     status === "running"
-      ? { status: "running", time: { start } }
+      ? { status: "running", time: { start }, input: overrides.input }
       : status === "completed"
-        ? { status: "completed", time: { start, end }, output: "result output" }
-        : { status: "error", time: { start, end }, error: "tool failed" }
+        ? { status: "completed", time: { start, end }, input: overrides.input, output: "result output" }
+        : { status: "error", time: { start, end }, input: overrides.input, error: "tool failed" }
 
   return {
     type: "message.part.updated",
@@ -291,6 +291,67 @@ describe("handleMessagePartUpdated", () => {
     expect(record.attributes?.["success"]).toBe(false)
     expect(record.attributes?.["error"]).toBe("tool failed")
     expect(pluginLog.calls.find(c => c.level === "error")?.level).toBe("error")
+  })
+
+  test("counts native skill tool loads on running", async () => {
+    const { ctx, counters, logger } = makeCtx()
+
+    await handleMessagePartUpdated(makeToolPartUpdated("running", {
+      tool: "skill",
+      input: { skill: "review" },
+    }), ctx)
+
+    expect(counters.skill.calls).toHaveLength(1)
+    expect(counters.skill.calls[0]!.attrs).toEqual({
+      "project.id": "proj_test",
+      "session.id": "ses_1",
+      skill_name: "review",
+      invocation_type: "tool",
+      tool_name: "skill",
+    })
+    expect(logger.records.some((record) => record.body === "skill_invoked")).toBe(true)
+  })
+
+  test("counts completed native skill tool load if running was missed", async () => {
+    const { ctx, counters } = makeCtx()
+
+    await handleMessagePartUpdated(makeToolPartUpdated("completed", {
+      tool: "skill",
+      input: { skillName: "review" },
+    }), ctx)
+
+    expect(counters.skill.calls).toHaveLength(1)
+    expect(counters.skill.calls[0]!.attrs["skill_name"]).toBe("review")
+  })
+
+  test("does not double-count native skill tool completion after running", async () => {
+    const { ctx, counters } = makeCtx()
+
+    await handleMessagePartUpdated(makeToolPartUpdated("running", {
+      tool: "skill",
+      input: { skill: "review" },
+    }), ctx)
+    await handleMessagePartUpdated(makeToolPartUpdated("completed", {
+      tool: "skill",
+      input: { skill: "review" },
+    }), ctx)
+
+    expect(counters.skill.calls).toHaveLength(1)
+  })
+
+  test("does not double-count repeated running updates for the same native skill tool call", async () => {
+    const { ctx, counters } = makeCtx()
+
+    await handleMessagePartUpdated(makeToolPartUpdated("running", {
+      tool: "skill",
+      input: { skill: "review" },
+    }), ctx)
+    await handleMessagePartUpdated(makeToolPartUpdated("running", {
+      tool: "skill",
+      input: { skill: "review" },
+    }), ctx)
+
+    expect(counters.skill.calls).toHaveLength(1)
   })
 
   test("removes entry from pendingToolSpans after completion", async () => {

--- a/tests/handlers/skill.test.ts
+++ b/tests/handlers/skill.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect } from "bun:test"
+import { createSkillCommandResolver, handleCommandExecuteBefore } from "../../src/handlers/skill.ts"
+import { makeCtx } from "../helpers.ts"
+
+function commandInput(command = "review") {
+  return {
+    command,
+    sessionID: "ses_1",
+    arguments: "sensitive prompt text",
+  }
+}
+
+describe("handleCommandExecuteBefore", () => {
+  test("increments skill counter when command resolves to a skill", async () => {
+    const { ctx, counters } = makeCtx("proj_test")
+
+    await handleCommandExecuteBefore(commandInput(), ctx, async () => ({
+      name: "review",
+      agent: "build",
+      subtask: true,
+    }))
+
+    expect(counters.skill.calls).toHaveLength(1)
+    expect(counters.skill.calls[0]!.attrs).toEqual({
+      "project.id": "proj_test",
+      "session.id": "ses_1",
+      skill_name: "review",
+      invocation_type: "command",
+      command_name: "review",
+      agent: "build",
+      subtask: true,
+    })
+  })
+
+  test("emits skill_invoked log without raw command arguments", async () => {
+    const { ctx, logger } = makeCtx("proj_test")
+
+    await handleCommandExecuteBefore(commandInput(), ctx, async () => ({
+      name: "review",
+      description: "Review the current diff",
+    }))
+
+    const record = logger.records.at(0)!
+    expect(record.body).toBe("skill_invoked")
+    expect(record.attributes?.["event.name"]).toBe("skill_invoked")
+    expect(record.attributes?.["skill_name"]).toBe("review")
+    expect(record.attributes?.["arguments_length"]).toBe("sensitive prompt text".length)
+    expect(record.attributes?.["arguments"]).toBeUndefined()
+    expect(record.attributes?.["description"]).toBe("Review the current diff")
+  })
+
+  test("does nothing when command is not a skill", async () => {
+    const { ctx, counters, logger } = makeCtx("proj_test")
+
+    await handleCommandExecuteBefore(commandInput("plain"), ctx, async () => undefined)
+
+    expect(counters.skill.calls).toHaveLength(0)
+    expect(logger.records).toHaveLength(0)
+  })
+
+  test("still emits log when skill.count is disabled", async () => {
+    const { ctx, counters, logger } = makeCtx("proj_test", ["skill.count"])
+
+    await handleCommandExecuteBefore(commandInput(), ctx, async () => ({ name: "review" }))
+
+    expect(counters.skill.calls).toHaveLength(0)
+    expect(logger.records.at(0)!.body).toBe("skill_invoked")
+  })
+})
+
+describe("createSkillCommandResolver", () => {
+  test("resolves commands marked with source skill from the command catalog", async () => {
+    const client = {
+      command: {
+        async list() {
+          return {
+            data: [
+              { name: "review", source: "skill", agent: "build", subtask: false },
+              { name: "plain", source: "command" },
+            ],
+          }
+        },
+      },
+    }
+    const pluginLogs: Array<{ level: string; message: string; extra?: Record<string, unknown> }> = []
+    const resolver = createSkillCommandResolver({
+      client,
+      serverUrl: new URL("http://127.0.0.1:40999"),
+      directory: "/repo",
+      log: async (level, message, extra) => { pluginLogs.push({ level, message, extra }) },
+    })
+
+    await resolver.refresh(true)
+
+    expect(await resolver.resolve("review")).toEqual({ name: "review", agent: "build", subtask: false })
+    expect(await resolver.resolve("plain")).toBeUndefined()
+    expect(pluginLogs.at(-1)?.extra?.["count"]).toBe(1)
+  })
+
+  test("falls back to raw /command catalog when client catalog lacks source metadata", async () => {
+    const client = {
+      command: {
+        async list() {
+          return {
+            data: [
+              { name: "review" },
+            ],
+          }
+        },
+      },
+    }
+    const requests: string[] = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      requests.push(input instanceof Request ? input.url : String(input))
+      return new Response(JSON.stringify([
+        { name: "review", source: "skill", agent: "build" },
+      ]), { status: 200, headers: { "content-type": "application/json" } })
+    }) as unknown as typeof fetch
+    try {
+      const resolver = createSkillCommandResolver({
+        client,
+        serverUrl: new URL("http://127.0.0.1:40999"),
+        directory: "/repo",
+        log: async () => {},
+      })
+
+      await resolver.refresh(true)
+
+      expect(requests).toHaveLength(1)
+      expect(new URL(requests[0]!).pathname).toBe("/command")
+      expect(new URL(requests[0]!).searchParams.get("directory")).toBe("/repo")
+      expect(await resolver.resolve("review")).toEqual({ name: "review", agent: "build" })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("preserves cached skills when catalog refresh fails", async () => {
+    let failClient = false
+    const client = {
+      command: {
+        async list() {
+          if (failClient) return { error: "unavailable" }
+          return {
+            data: [
+              { name: "review", source: "skill" },
+            ],
+          }
+        },
+      },
+    }
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => new Response("unavailable", { status: 500 })) as unknown as typeof fetch
+    try {
+      const resolver = createSkillCommandResolver({
+        client,
+        serverUrl: new URL("http://127.0.0.1:40999"),
+        directory: "/repo",
+        log: async () => {},
+      })
+
+      await resolver.refresh(true)
+      expect(await resolver.resolve("review")).toEqual({ name: "review" })
+
+      failClient = true
+      await resolver.refresh(true)
+
+      expect(await resolver.resolve("review")).toEqual({ name: "review" })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("preserves cached skills when client catalog lacks source metadata and raw lookups fail", async () => {
+    let metadataLessClient = false
+    const client = {
+      command: {
+        async list() {
+          if (metadataLessClient) {
+            return {
+              data: [
+                { name: "review" },
+              ],
+            }
+          }
+          return {
+            data: [
+              { name: "review", source: "skill" },
+            ],
+          }
+        },
+      },
+    }
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async () => new Response("unavailable", { status: 500 })) as unknown as typeof fetch
+    try {
+      const resolver = createSkillCommandResolver({
+        client,
+        serverUrl: new URL("http://127.0.0.1:40999"),
+        directory: "/repo",
+        log: async () => {},
+      })
+
+      await resolver.refresh(true)
+      expect(await resolver.resolve("review")).toEqual({ name: "review" })
+
+      metadataLessClient = true
+      await resolver.refresh(true)
+
+      expect(await resolver.resolve("review")).toEqual({ name: "review" })
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,5 @@
 import type { HandlerContext, Instruments } from "../src/types.ts"
-import type { LogRecord } from "@opentelemetry/api-logs"
+import { SeverityNumber, type LogRecord } from "@opentelemetry/api-logs"
 import type { Counter, Gauge, Histogram, Span, SpanOptions, Tracer, Context, SpanContext, SpanStatus, Attributes } from "@opentelemetry/api"
 import { ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api"
 
@@ -133,6 +133,7 @@ export type MockContext = {
     modelUsage: SpyCounter
     retry: SpyCounter
     subtask: SpyCounter
+    skill: SpyCounter
   }
   histograms: {
     tool: SpyHistogram
@@ -159,6 +160,7 @@ export function makeCtx(projectID = "proj_test", disabledMetrics: string[] = [],
   const modelUsage = makeCounter()
   const retry = makeCounter()
   const subtask = makeCounter()
+  const skill = makeCounter()
   const toolHistogram = makeHistogram()
   const sessionDurationHistogram = makeHistogram()
   const sessionTokenGauge = makeHistogram()
@@ -184,6 +186,7 @@ export function makeCtx(projectID = "proj_test", disabledMetrics: string[] = [],
     modelUsageCounter: modelUsage as unknown as Counter,
     retryCounter: retry as unknown as Counter,
     subtaskCounter: subtask as unknown as Counter,
+    skillCounter: skill as unknown as Counter,
   }
 
   const ctx: HandlerContext = {
@@ -192,6 +195,7 @@ export function makeCtx(projectID = "proj_test", disabledMetrics: string[] = [],
       if (!logsEnabled) return
       logger.emit(record)
     },
+    logSeverity: { info: SeverityNumber.INFO, error: SeverityNumber.ERROR },
     instruments,
     commonAttrs: { "project.id": projectID },
     pendingToolSpans: new Map(),
@@ -211,7 +215,7 @@ export function makeCtx(projectID = "proj_test", disabledMetrics: string[] = [],
 
   return {
     ctx,
-    counters: { session, token, cost, lines, commit, cache, message, modelUsage, retry, subtask },
+    counters: { session, token, cost, lines, commit, cache, message, modelUsage, retry, subtask, skill },
     histograms: { tool: toolHistogram, sessionDuration: sessionDurationHistogram },
     gauges: { sessionToken: sessionTokenGauge, sessionCost: sessionCostGauge, linesTotal: linesTotalGauge },
     logger,


### PR DESCRIPTION
## Summary
- add `opencode.skill.count` counter for skill invocations
- emit `skill_invoked` log events with project/session/agent/skill metadata
- resolve skill commands from the opencode command catalog, with `/command` and `/api/command` fallbacks
- document the new metric, log event, and disable flag behavior

## Validation
- `bun run lint`
- `bun run check:jsdoc-coverage`
- `bun run typecheck`
- `bun test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added skill invocation telemetry using the new `opencode.skill.count` metric and `skill_invoked` log events, covering both skill commands and native skill tool activity.
  * Introduced `serverUrl` as part of the plugin configuration to enable skill-command resolution during startup.

* **Documentation**
  * Updated README to document `opencode.skill.count` and expanded `OPENCODE_DISABLE_METRICS` examples.

* **Tests**
  * Added coverage for skill counting, redacted argument handling, and ensuring logs still emit when `skill.count` is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->