### PR TITLE
fix(handlers): keep root session span open across session.idle

### DIFF
--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -1,6 +1,6 @@
 import { SeverityNumber } from "@opentelemetry/api-logs"
 import { SpanStatusCode, trace } from "@opentelemetry/api"
-import type { EventSessionCreated, EventSessionIdle, EventSessionError, EventSessionStatus } from "@opencode-ai/sdk"
+import type { EventSessionCreated, EventSessionIdle, EventSessionDeleted, EventSessionError, EventSessionStatus } from "@opencode-ai/sdk"
 import { AGENT_NAME, OpenInferenceSpanKind, SemanticConventions, SESSION_ID } from "@arizeai/openinference-semantic-conventions"
 import { agentAttrs, errorSummary, getSessionAgentMeta, setBoundedMap, isMetricEnabled, isTraceEnabled } from "../util.ts"
 import type { HandlerContext, SessionAgentType } from "../types.ts"
@@ -88,13 +88,21 @@ function sweepSession(sessionID: string, ctx: HandlerContext) {
   }
 }
 
-/** Emits a `session.idle` log event, records duration and session total histograms, ends the session span, and clears pending state. */
+/**
+ * Emits a `session.idle` log event and records duration/total histograms for the turn
+ * that just completed, then sweeps per-turn pending state (tool/message spans, pending
+ * permissions, the cached user prompt).
+ *
+ * Unlike a one-shot turn, an opencode session stays alive and may receive further user
+ * messages, so `session.total_*` totals and the root `opencode.session` span are kept
+ * open across `session.idle` events: ending the span here would otherwise orphan every
+ * subsequent turn's LLM/tool spans as new root traces. The span and totals are only
+ * finalized in `handleSessionDeleted` (or `handleSessionError`/shutdown).
+ */
 export function handleSessionIdle(e: EventSessionIdle, ctx: HandlerContext) {
   const sessionID = e.properties.sessionID
   const totals = ctx.sessionTotals.get(sessionID)
   const { agentName, agentType } = getSessionAgentMeta(sessionID, ctx)
-  ctx.sessionTotals.delete(sessionID)
-  ctx.sessionDiffTotals.delete(sessionID)
   sweepSession(sessionID, ctx)
 
   const attrs = { ...ctx.commonAttrs, "session.id": sessionID }
@@ -114,19 +122,14 @@ export function handleSessionIdle(e: EventSessionIdle, ctx: HandlerContext) {
   }
 
   const sessionSpan = ctx.sessionSpans.get(sessionID)
-  if (sessionSpan) {
-    if (totals) {
-      sessionSpan.setAttributes({
-        [AGENT_NAME]: totals.agent,
-        "agent.type": totals.agentType,
-        "session.total_tokens": totals.tokens,
-        "session.total_cost_usd": totals.cost,
-        "session.total_messages": totals.messages,
-      })
-    }
-    sessionSpan.setStatus({ code: SpanStatusCode.OK })
-    sessionSpan.end()
-    ctx.sessionSpans.delete(sessionID)
+  if (sessionSpan && totals) {
+    sessionSpan.setAttributes({
+      [AGENT_NAME]: totals.agent,
+      "agent.type": totals.agentType,
+      "session.total_tokens": totals.tokens,
+      "session.total_cost_usd": totals.cost,
+      "session.total_messages": totals.messages,
+    })
   }
 
   ctx.emitLog({
@@ -149,6 +152,37 @@ export function handleSessionIdle(e: EventSessionIdle, ctx: HandlerContext) {
     sessionID,
     ...(totals ? { duration_ms, total_tokens: totals.tokens, total_cost_usd: totals.cost, total_messages: totals.messages } : {}),
   })
+}
+
+/**
+ * Final cleanup when a session is removed: ends the root `opencode.session` span with the
+ * last known totals, and clears the session's accumulated totals and pending state. This is
+ * the counterpart to the "keep the span open across `session.idle`" behavior above — it's
+ * where a long-lived session's span and totals actually get torn down.
+ */
+export function handleSessionDeleted(e: EventSessionDeleted, ctx: HandlerContext) {
+  const sessionID = e.properties.info.id
+  const totals = ctx.sessionTotals.get(sessionID)
+  ctx.sessionTotals.delete(sessionID)
+  ctx.sessionDiffTotals.delete(sessionID)
+  sweepSession(sessionID, ctx)
+
+  const sessionSpan = ctx.sessionSpans.get(sessionID)
+  if (sessionSpan) {
+    if (totals) {
+      sessionSpan.setAttributes({
+        [AGENT_NAME]: totals.agent,
+        "session.total_tokens": totals.tokens,
+        "session.total_cost_usd": totals.cost,
+        "session.total_messages": totals.messages,
+      })
+    }
+    sessionSpan.setStatus({ code: SpanStatusCode.OK })
+    sessionSpan.end()
+    ctx.sessionSpans.delete(sessionID)
+  }
+
+  ctx.log("debug", "otel: session.deleted", { sessionID })
 }
 
 /** Emits a `session.error` log event, ends the session span with error status, and clears any pending state for the session. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { SeverityNumber } from "@opentelemetry/api-logs"
 import { logs } from "@opentelemetry/api-logs"
-import { ROOT_CONTEXT, trace } from "@opentelemetry/api"
+import { ROOT_CONTEXT, SpanStatusCode, trace } from "@opentelemetry/api"
 import { AGENT_NAME } from "@arizeai/openinference-semantic-conventions"
 import pkg from "../package.json" with { type: "json" }
 import type {
   EventSessionCreated,
   EventSessionIdle,
+  EventSessionDeleted,
   EventSessionError,
   EventSessionStatus,
   EventMessageUpdated,
@@ -21,7 +22,7 @@ import { loadConfig, parseAttributePairs, resolveHelperPath, resolveLogLevel } f
 import { probeEndpoint } from "./probe.ts"
 import { setupOtel, createInstruments } from "./otel.ts"
 import { remoteParentContext } from "./trace-context.ts"
-import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSessionStatus } from "./handlers/session.ts"
+import { handleSessionCreated, handleSessionIdle, handleSessionDeleted, handleSessionError, handleSessionStatus } from "./handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "./handlers/message.ts"
 import { handlePermissionUpdated, handlePermissionReplied } from "./handlers/permission.ts"
 import { handleSessionDiff, handleCommandExecuted } from "./handlers/activity.ts"
@@ -146,6 +147,20 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
   }
 
   async function shutdown() {
+    for (const [sessionID, sessionSpan] of sessionSpans) {
+      const totals = sessionTotals.get(sessionID)
+      if (totals) {
+        sessionSpan.setAttributes({
+          [AGENT_NAME]: totals.agent,
+          "session.total_tokens": totals.tokens,
+          "session.total_cost_usd": totals.cost,
+          "session.total_messages": totals.messages,
+        })
+      }
+      sessionSpan.setStatus({ code: SpanStatusCode.OK })
+      sessionSpan.end()
+    }
+    sessionSpans.clear()
     await Promise.allSettled([meterProvider.shutdown(), loggerProvider.shutdown(), tracerProvider.shutdown()])
   }
 
@@ -230,6 +245,9 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
           break
         case "session.idle":
           handleSessionIdle(event as EventSessionIdle, ctx)
+          break
+        case "session.deleted":
+          handleSessionDeleted(event as EventSessionDeleted, ctx)
           break
         case "session.error":
           handleSessionError(event as EventSessionError, ctx)

--- a/tests/handlers/session.test.ts
+++ b/tests/handlers/session.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test"
-import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSessionStatus } from "../../src/handlers/session.ts"
+import { handleSessionCreated, handleSessionIdle, handleSessionDeleted, handleSessionError, handleSessionStatus } from "../../src/handlers/session.ts"
 import { makeCtx, makeTracer } from "../helpers.ts"
-import type { EventSessionCreated, EventSessionIdle, EventSessionError, EventSessionStatus } from "@opencode-ai/sdk"
+import type { EventSessionCreated, EventSessionIdle, EventSessionDeleted, EventSessionError, EventSessionStatus } from "@opencode-ai/sdk"
 import type { Span } from "@opentelemetry/api"
 
 function makeSessionCreated(sessionID: string, createdAt = 1000, parentID?: string): EventSessionCreated {
@@ -153,12 +153,36 @@ describe("handleSessionIdle", () => {
     expect(gauges.sessionCost.calls).toHaveLength(0)
   })
 
-  test("removes sessionTotals entry on idle", async () => {
+  test("keeps sessionTotals entry across idle so later turns keep accumulating", async () => {
     const { ctx } = makeCtx()
     await handleSessionCreated(makeSessionCreated("ses_1"), ctx)
     expect(ctx.sessionTotals.has("ses_1")).toBe(true)
     handleSessionIdle(makeSessionIdle("ses_1"), ctx)
+    expect(ctx.sessionTotals.has("ses_1")).toBe(true)
+  })
+})
+
+describe("handleSessionDeleted", () => {
+  function makeSessionDeleted(sessionID: string): EventSessionDeleted {
+    return { type: "session.deleted", properties: { info: { id: sessionID } } } as unknown as EventSessionDeleted
+  }
+
+  test("removes sessionTotals and sessionDiffTotals entries", async () => {
+    const { ctx } = makeCtx()
+    await handleSessionCreated(makeSessionCreated("ses_1"), ctx)
+    ctx.sessionDiffTotals.set("ses_1", { additions: 1, deletions: 2 })
+    handleSessionDeleted(makeSessionDeleted("ses_1"), ctx)
     expect(ctx.sessionTotals.has("ses_1")).toBe(false)
+    expect(ctx.sessionDiffTotals.has("ses_1")).toBe(false)
+  })
+
+  test("ends the session span with OK status", async () => {
+    const { ctx, tracer } = makeCtx()
+    await handleSessionCreated(makeSessionCreated("ses_1"), ctx)
+    handleSessionDeleted(makeSessionDeleted("ses_1"), ctx)
+    const span = tracer.spans[0]!
+    expect(span.ended).toBe(true)
+    expect(ctx.sessionSpans.has("ses_1")).toBe(false)
   })
 })
 

--- a/tests/handlers/spans.test.ts
+++ b/tests/handlers/spans.test.ts
@@ -16,13 +16,14 @@ import {
   TOOL_NAME,
 } from "@arizeai/openinference-semantic-conventions"
 import type { Span } from "@opentelemetry/api"
-import { handleSessionCreated, handleSessionIdle, handleSessionError } from "../../src/handlers/session.ts"
+import { handleSessionCreated, handleSessionIdle, handleSessionDeleted, handleSessionError } from "../../src/handlers/session.ts"
 import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "../../src/handlers/message.ts"
 import { remoteParentContext } from "../../src/trace-context.ts"
 import { makeCtx, makeTracer, type SpySpan } from "../helpers.ts"
 import type {
   EventSessionCreated,
   EventSessionIdle,
+  EventSessionDeleted,
   EventSessionError,
   EventMessageUpdated,
   EventMessagePartUpdated,
@@ -39,6 +40,10 @@ function makeSessionCreated(sessionID: string, createdAt = 1000, parentID?: stri
 
 function makeSessionIdle(sessionID: string): EventSessionIdle {
   return { type: "session.idle", properties: { sessionID } } as EventSessionIdle
+}
+
+function makeSessionDeleted(sessionID: string): EventSessionDeleted {
+  return { type: "session.deleted", properties: { info: { id: sessionID } } } as unknown as EventSessionDeleted
 }
 
 function makeSessionError(sessionID?: string, error?: { name: string }): EventSessionError {
@@ -157,17 +162,17 @@ describe("session spans", () => {
     expect(tracer.spans[0]!.parentSpan?.spanContext().spanId).toBe("00f067aa0ba902b7")
   })
 
-  test("ends session span with OK status on session.idle", () => {
+  test("keeps session span open across session.idle so later turns can nest under it", () => {
     const { ctx, tracer } = makeCtx()
     handleSessionCreated(makeSessionCreated("ses_1"), ctx)
     handleSessionIdle(makeSessionIdle("ses_1"), ctx)
     const span = tracer.spans[0]!
-    expect(span.ended).toBe(true)
-    expect(span.status.code).toBe(SpanStatusCode.OK)
-    expect(ctx.sessionSpans.has("ses_1")).toBe(false)
+    expect(span.ended).toBe(false)
+    expect(ctx.sessionSpans.has("ses_1")).toBe(true)
+    expect(ctx.sessionTotals.has("ses_1")).toBe(true)
   })
 
-  test("sets session total attributes before ending on idle", () => {
+  test("sets session total attributes on session.idle without ending the span", () => {
     const { ctx, tracer } = makeCtx()
     handleSessionCreated(makeSessionCreated("ses_1"), ctx)
     ctx.sessionTotals.set("ses_1", { startMs: Date.now() - 100, tokens: 250, cost: 0.05, messages: 3, agent: "build", agentType: "primary" })
@@ -178,6 +183,31 @@ describe("session spans", () => {
     expect(span.attributes["session.total_messages"]).toBe(3)
     expect(span.attributes[AGENT_NAME]).toBe("build")
     expect(span.attributes["agent.type"]).toBe("primary")
+    expect(span.ended).toBe(false)
+  })
+
+  test("ends session span with OK status and clears totals on session.deleted", () => {
+    const { ctx, tracer } = makeCtx()
+    handleSessionCreated(makeSessionCreated("ses_1"), ctx)
+    ctx.sessionTotals.set("ses_1", { startMs: Date.now() - 100, tokens: 250, cost: 0.05, messages: 3, agent: "build", agentType: "primary" })
+    handleSessionIdle(makeSessionIdle("ses_1"), ctx)
+    handleSessionDeleted(makeSessionDeleted("ses_1"), ctx)
+    const span = tracer.spans[0]!
+    expect(span.ended).toBe(true)
+    expect(span.status.code).toBe(SpanStatusCode.OK)
+    expect(span.attributes["session.total_tokens"]).toBe(250)
+    expect(ctx.sessionSpans.has("ses_1")).toBe(false)
+    expect(ctx.sessionTotals.has("ses_1")).toBe(false)
+  })
+
+  test("a second turn's LLM span nests under the still-open session span after idle", () => {
+    const { ctx, tracer } = makeCtx()
+    handleSessionCreated(makeSessionCreated("ses_1"), ctx)
+    handleSessionIdle(makeSessionIdle("ses_1"), ctx)
+    startMessageSpan("ses_1", "msg_2", "claude-3-5-sonnet", "anthropic", 5000, ctx)
+    const sessionSpan = tracer.spans[0]!
+    const llmSpan = tracer.spans[1]!
+    expect(llmSpan.parentSpan).toBe(sessionSpan)
   })
 
   test("ends session span with ERROR status on session.error", () => {


### PR DESCRIPTION
## Description

The `opencode.session` span and accumulated session totals were ended and deleted on the first `session.idle` event. Since a session keeps receiving turns after going idle, every subsequent turn's LLM/tool spans had no local session span to nest under and became orphaned root traces, with their token/cost contributions silently dropped from `session.total_*`.

Keeps the session span and totals alive across `session.idle` (only snapshotting attributes), and finalizes them in a new `handleSessionDeleted` handler, on `session.error`, or on process shutdown.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependency updates, etc.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

Supersedes #64 and #70 — same fix, rebased as a single commit on current `main` on a proper feature branch.

## Additional context

`bun test` — 282 pass, 0 fail.