### PR TITLE
fix agent name showing 'unknown' issue

### DIFF
--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -453,3 +453,30 @@ export function startMessageSpan(
   )
   setBoundedMap(ctx.messageSpans, msgKey, msgSpan)
 }
+
+/**
+ * Initialises or updates the per-session agent metadata when a new user prompt
+ * arrives. Creates a fresh `SessionTotals` entry if none exists for this session
+ * (e.g. the session was started before the current plugin process). Updates the
+ * agent name on subsequent messages within the same session.
+ */
+export function handleChatMessage(
+  sessionID: string,
+  agent: string | undefined,
+  ctx: Pick<HandlerContext, "sessionTotals">,
+) {
+  const agentName = agent ?? "unknown"
+  const totals = ctx.sessionTotals.get(sessionID)
+  if (totals) {
+    if (agent) totals.agent = agentName
+  } else {
+    ctx.sessionTotals.set(sessionID, {
+      startMs: Date.now(),
+      tokens: 0,
+      cost: 0,
+      messages: 0,
+      agent: agentName,
+      agentType: "primary",
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,9 +183,14 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
 
     "chat.message": safe("chat.message", async (input, output) => {
       const agent = input.agent ?? "unknown"
+      let totals = sessionTotals.get(input.sessionID)
+      if (totals) {
+        if (input.agent) totals.agent = input.agent
+      } else {
+        totals = { startMs: Date.now(), tokens: 0, cost: 0, messages: 0, agent, agentType: "primary" }
+        sessionTotals.set(input.sessionID, totals)
+      }
       const { agentType } = getSessionAgentMeta(input.sessionID, ctx)
-      const totals = sessionTotals.get(input.sessionID)
-      if (totals) totals.agent = agent
       const sessionSpan = sessionSpans.get(input.sessionID)
       if (sessionSpan) sessionSpan.setAttributes({ [AGENT_NAME]: agent, "agent.type": agentType })
       const promptText = output.parts.map((part) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { probeEndpoint } from "./probe.ts"
 import { setupOtel, createInstruments } from "./otel.ts"
 import { remoteParentContext } from "./trace-context.ts"
 import { handleSessionCreated, handleSessionIdle, handleSessionError, handleSessionStatus } from "./handlers/session.ts"
-import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from "./handlers/message.ts"
+import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan, handleChatMessage } from "./handlers/message.ts"
 import { handlePermissionUpdated, handlePermissionReplied } from "./handlers/permission.ts"
 import { handleSessionDiff, handleCommandExecuted } from "./handlers/activity.ts"
 import { agentAttrs, getSessionAgentMeta } from "./util.ts"
@@ -183,13 +183,7 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
 
     "chat.message": safe("chat.message", async (input, output) => {
       const agent = input.agent ?? "unknown"
-      let totals = sessionTotals.get(input.sessionID)
-      if (totals) {
-        if (input.agent) totals.agent = input.agent
-      } else {
-        totals = { startMs: Date.now(), tokens: 0, cost: 0, messages: 0, agent, agentType: "primary" }
-        sessionTotals.set(input.sessionID, totals)
-      }
+      handleChatMessage(input.sessionID, input.agent, ctx)
       const { agentType } = getSessionAgentMeta(input.sessionID, ctx)
       const sessionSpan = sessionSpans.get(input.sessionID)
       if (sessionSpan) sessionSpan.setAttributes({ [AGENT_NAME]: agent, "agent.type": agentType })

--- a/tests/handlers/message.test.ts
+++ b/tests/handlers/message.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { handleMessageUpdated, handleMessagePartUpdated } from "../../src/handlers/message.ts"
+import { handleMessageUpdated, handleMessagePartUpdated, handleChatMessage } from "../../src/handlers/message.ts"
 import { makeCtx } from "../helpers.ts"
 import type { EventMessageUpdated, EventMessagePartUpdated } from "@opencode-ai/sdk"
 
@@ -236,6 +236,40 @@ describe("handleMessageUpdated", () => {
       ctx,
     )
     expect(logger.records.at(0)!.timestamp).toBe(5000)
+  })
+})
+
+describe("handleChatMessage", () => {
+  test("creates sessionTotals entry with agent when none exists", () => {
+    const { ctx } = makeCtx()
+    handleChatMessage("ses_no_totals", "build", ctx)
+    const totals = ctx.sessionTotals.get("ses_no_totals")!
+    expect(totals.agent).toBe("build")
+    expect(totals.agentType).toBe("primary")
+    expect(totals.tokens).toBe(0)
+    expect(totals.cost).toBe(0)
+    expect(totals.messages).toBe(0)
+    expect(totals.startMs).toBeGreaterThan(0)
+  })
+
+  test("defaults agent to 'unknown' when agent is undefined", () => {
+    const { ctx } = makeCtx()
+    handleChatMessage("ses_no_agent", undefined, ctx)
+    expect(ctx.sessionTotals.get("ses_no_agent")!.agent).toBe("unknown")
+  })
+
+  test("updates agent on existing entry", () => {
+    const { ctx } = makeCtx()
+    ctx.sessionTotals.set("ses_1", { startMs: 1000, tokens: 100, cost: 0.01, messages: 1, agent: "build", agentType: "primary" })
+    handleChatMessage("ses_1", "plan", ctx)
+    expect(ctx.sessionTotals.get("ses_1")!.agent).toBe("plan")
+  })
+
+  test("does not override agent with 'unknown' on existing entry when called without agent", () => {
+    const { ctx } = makeCtx()
+    ctx.sessionTotals.set("ses_1", { startMs: 1000, tokens: 100, cost: 0.01, messages: 1, agent: "build", agentType: "primary" })
+    handleChatMessage("ses_1", undefined, ctx)
+    expect(ctx.sessionTotals.get("ses_1")!.agent).toBe("build")
   })
 })
 


### PR DESCRIPTION
## Description

Fix Issue: #72 

When a user sends a message to an existing session (no `session.created` event), the `sessionTotals` map has no entry for that session. The `chat.message` hook only mutated an existing entry but did not create one. This caused `getSessionAgentMeta` to fall back to "unknown" for all subsequent metric counters, trace span attributes, and log event attributes.
This fix creates a `sessionTotals` entry in the `chat.message` hook when one does not exist, using `input.agent` as the agent name. Since `chat.message` fires before any code that reads `sessionTotals`, this ensures the correct agent is always available.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependency updates, etc.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly: **no need to update document**
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

https://github.com/DEVtheOPS/opencode-plugin-otel/issues/72

## Additional context

<img width="2764" height="354" alt="image" src="https://github.com/user-attachments/assets/a79c1070-9e5f-4a26-afa3-1ecca4ee4af4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat session initialization to properly handle edge cases where session data is absent, ensuring more reliable and consistent tracking of chat sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->