### PR TITLE
ci: add Codex review workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,77 @@
+name: Codex Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  codex:
+    name: Review Pull Request
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          persist-credentials: false
+
+      - name: Fetch pull request refs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch --no-tags origin \
+            "$PR_BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+
+      - name: Run Codex review
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          permission-profile: ":workspace"
+          prompt: |
+            This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
+
+            Review only the changes introduced by this pull request. Focus on bugs,
+            behavior regressions, security risks, and missing tests. Keep feedback
+            concise and specific, with file and line references where possible.
+
+            Useful commands:
+            git log --oneline ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+            git diff --stat ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+            git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Pull request title and body:
+            ----
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.body }}
+
+  post_feedback:
+    name: Post Codex Feedback
+    needs: codex
+    if: needs.codex.outputs.final_message != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Comment on pull request
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.CODEX_FINAL_MESSAGE,
+            });

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -10,7 +10,10 @@ permissions:
 jobs:
   codex:
     name: Review Pull Request
-    if: github.event.pull_request.draft == false
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
@@ -56,7 +59,9 @@ jobs:
   post_feedback:
     name: Post Codex Feedback
     needs: codex
-    if: needs.codex.outputs.final_message != ''
+    if: |
+      needs.codex.result == 'success' &&
+      needs.codex.outputs.final_message != ''
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -69,9 +74,29 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            await github.rest.issues.createComment({
+            const marker = '<!-- codex-review-comment -->';
+            const body = `${marker}\n${process.env.CODEX_FINAL_MESSAGE}`;
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: process.env.CODEX_FINAL_MESSAGE,
             });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that runs openai/codex-action on pull requests and posts Codex review feedback as a PR comment.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Chore (dependency updates, etc.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification

## Related issues

None.

## Additional context

Uses `OPENAI_API_KEY` from repository secrets and `permission-profile: ":workspace"` per the Codex Action recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Codex review comments on pull requests.
  * Reviews run on new updates and reopened PRs, and only after a PR is ready for review.
  * When available, the review result is posted directly as a PR comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->