### PR TITLE
fix: preserve bounded map updates

### DIFF
--- a/src/handlers/activity.ts
+++ b/src/handlers/activity.ts
@@ -28,14 +28,7 @@ export function handleSessionDiff(e: EventSessionDiff, ctx: HandlerContext) {
   const deltaAdded = totalAdded - prev.additions
   const deltaRemoved = totalRemoved - prev.deletions
   const nextTotals = { additions: totalAdded, deletions: totalRemoved }
-  if (ctx.sessionDiffTotals.has(sessionID)) {
-    // Existing session: update in place. Calling setBoundedMap on a full map would
-    // evict an unrelated session here, and that session's next session.diff would
-    // be treated as first-seen — reintroducing the cumulative double-count bug.
-    ctx.sessionDiffTotals.set(sessionID, nextTotals)
-  } else {
-    setBoundedMap(ctx.sessionDiffTotals, sessionID, nextTotals)
-  }
+  setBoundedMap(ctx.sessionDiffTotals, sessionID, nextTotals)
 
   const baseAttrs = { ...ctx.commonAttrs, "session.id": sessionID }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ export function errorSummary(err: { name: string; data?: unknown } | undefined):
  * has reached `MAX_PENDING` capacity to prevent unbounded memory growth.
  */
 export function setBoundedMap<K, V>(map: Map<K, V>, key: K, value: V) {
-  if (map.size >= MAX_PENDING) {
+  if (!map.has(key) && map.size >= MAX_PENDING) {
     const [firstKey] = map.keys()
     if (firstKey !== undefined) map.delete(firstKey)
   }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -62,6 +62,19 @@ describe("setBoundedMap", () => {
     expect(map.get("a")).toBe(2)
     expect(map.size).toBe(1)
   })
+
+  test("updates an existing key at capacity without evicting another entry", () => {
+    const map = new Map<string, number>()
+    for (let i = 0; i < MAX_PENDING; i++) {
+      setBoundedMap(map, `key-${i}`, i)
+    }
+
+    setBoundedMap(map, "key-10", 1000)
+
+    expect(map.size).toBe(MAX_PENDING)
+    expect(map.get("key-10")).toBe(1000)
+    expect(map.has("key-0")).toBe(true)
+  })
 })
 
 describe("isMetricEnabled", () => {


### PR DESCRIPTION
## Summary

- update `setBoundedMap` so overwriting an existing key does not evict the oldest unrelated entry when the map is already at `MAX_PENDING`
- add regression coverage for the at-capacity update case

## Why

`setBoundedMap` is used for session/run/message bookkeeping as well as bounded pending state. Before this change, refreshing an existing key while the map was full still deleted the oldest entry first. That means an ordinary update to an existing session/run key could drop unrelated telemetry state even though no new entry was being added.

`session.diff` already had a local workaround for this class of issue; this makes the shared helper preserve existing-key updates consistently for every caller.

## Validation

- `bun test tests/util.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun test`
- `bun run build`
- `git diff --check`
