### PR TITLE
fix(ci): use compatible Node version for npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "24"
 
       - name: Update npm
         run: npm install -g npm@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [1.3.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v1.2.2...v1.3.0) (2026-07-06)
 
-
 ### Features
 
 * **config:** support plugin tuple options ([f8be232](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/f8be2328642beb50b093a52477e8621aa07f76ba))
 
 ## [1.2.2](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v1.2.1...v1.2.2) (2026-07-02)
 
-
 ### Bug Fixes
 
 * flush telemetry for short-lived runs ([df37dd0](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/df37dd053b8386b95f1fba7a2042f4a83fce0539))
 
 ## [1.2.1](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v1.2.0...v1.2.1) (2026-06-25)
-
 
 ### Bug Fixes
 
@@ -30,12 +27,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [1.2.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v1.1.0...v1.2.0) (2026-06-20)
 
-
 ### Features
 
 * **config:** support OPENCODE_SPAN_ATTRIBUTES ([93866c5](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/93866c5b09788f3a3f1b9162be0ed028196c4e83))
 * **handlers:** add agent metadata to logs and spans ([c2759e9](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/c2759e97401f1460ab8143cb04f2d0fb2fb05e29))
-
 
 ### Bug Fixes
 
@@ -43,12 +38,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [1.1.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v1.0.0...v1.1.0) (2026-06-04)
 
-
 ### Features
 
 * **trace:** support remote W3C parent context ([1da0a85](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/1da0a857e9303a8f7020f20627d01fecb95cfad0))
 * **trace:** support remote W3C parent context ([83e3d42](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/83e3d4211400eb49520c7b58bcaeff262763e799))
-
 
 ### Bug Fixes
 
@@ -56,7 +49,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 * **probe:** reject scheme-less endpoint URLs ([df7a62b](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/df7a62b3cd801f753d4a03342fc178fb4aac2874))
 
 ## [1.0.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v0.9.0...v1.0.0) (2026-05-18)
-
 
 ### ⚠ BREAKING CHANGES
 
@@ -66,7 +58,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 * **otel:** prewarm dynamic OTLP headers helper ([6f62b8b](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/6f62b8bc03382c2d451d0538d72dffb44757b16c))
 
-
 ### Bug Fixes
 
 * **handlers:** address code-review feedback on lines_of_code semantics ([a25022c](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/a25022c17cb912dedfe0dcd3b092db7bbee97e85))
@@ -75,11 +66,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [0.9.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v0.8.0...v0.9.0) (2026-05-01)
 
-
 ### Features
 
 * **otel:** refresh dynamic headers on auth failure ([b65dd2e](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/b65dd2e157a6e87b77f2641df63407256f300f82))
-
 
 ### Bug Fixes
 
@@ -90,18 +79,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [0.8.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v0.7.0...v0.8.0) (2026-04-21)
 
-
 ### Features
 
 * **traces:** align spans with OpenInference semantics ([ce6ca28](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/ce6ca28100ab65eb6e28ce8842c5d0f641e6bd59))
 
 ## [0.7.0](https://github.com/DEVtheOPS/opencode-plugin-otel/compare/v0.6.0...v0.7.0) (2026-04-13)
 
-
 ### Features
 
 * **otel:** add OTLP HTTP exporter support ([d679862](https://github.com/DEVtheOPS/opencode-plugin-otel/commit/d679862a88df831685e142fb0cb40db16225d5c8))
-
 
 ### Bug Fixes
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,12 +1,19 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "noEmit": false,
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"],
-  "exclude": ["eslint.config.mjs", "dist", "scripts", "tests"]
+  "exclude": [
+    "eslint.config.mjs",
+    "dist",
+    "scripts",
+    "tests"
+  ],
+  "extends": "./tsconfig.json",
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
## Summary
- run the npm publishing job on the current Node 24 line
- keep `npm@latest` compatible for provenance publishing
- include formatting updates produced by the repository pre-commit hooks

## Verification
- `pre-commit run --all-files`
- `bun run typecheck`
- `bun test` (302 passed)