### PR TITLE
feat(telemetry): add canonical GenAI provider names

### DIFF
--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -30,6 +30,7 @@ import {
 import {
   agentAttrs,
   errorSummary,
+  genAiProviderName,
   setBoundedMap,
   accumulateSessionTotals,
   getSessionAgentMeta,
@@ -163,6 +164,7 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
         "session.id": sessionID,
         model: modelID,
         provider: providerID,
+        "gen_ai.provider.name": genAiProviderName(providerID),
         ...agentAttrs(agentName, agentType),
         error: errorSummary(assistant.error),
         duration_ms: duration,
@@ -189,6 +191,7 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
         "session.id": sessionID,
         model: modelID,
         provider: providerID,
+        "gen_ai.provider.name": genAiProviderName(providerID),
         ...agentAttrs(agentName, agentType),
         cost_usd: assistant.cost,
         duration_ms: duration,
@@ -441,6 +444,7 @@ export function startMessageSpan(
         "agent.type": agentType,
         [LLM_SYSTEM]: providerID,
         [LLM_PROVIDER]: providerID,
+        "gen_ai.provider.name": genAiProviderName(providerID),
         [LLM_MODEL_NAME]: modelID,
         ...(inputText
           ? {

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,6 +2,17 @@ import { trace } from "@opentelemetry/api"
 import { MAX_PENDING } from "./types.ts"
 import type { HandlerContext, SessionAgentType } from "./types.ts"
 
+const GEN_AI_PROVIDER_NAMES: Readonly<Record<string, string>> = {
+  "amazon-bedrock": "aws.bedrock",
+  azure: "azure.ai.openai",
+  "azure-cognitive-services": "azure.ai.openai",
+  google: "gcp.gemini",
+  "google-vertex": "gcp.vertex_ai",
+  "google-vertex-anthropic": "gcp.vertex_ai",
+  mistral: "mistral_ai",
+  xai: "x_ai",
+}
+
 /** Returns a human-readable summary string from an opencode error object. */
 export function errorSummary(err: { name: string; data?: unknown } | undefined): string {
   if (!err) return "unknown"
@@ -9,6 +20,11 @@ export function errorSummary(err: { name: string; data?: unknown } | undefined):
     return `${err.name}: ${(err.data as { message: string }).message}`
   }
   return err.name
+}
+
+/** Returns the canonical OTel GenAI provider name, preserving unknown provider IDs. */
+export function genAiProviderName(providerID: string): string {
+  return GEN_AI_PROVIDER_NAMES[providerID] ?? providerID
 }
 
 /**

--- a/tests/handlers/message.test.ts
+++ b/tests/handlers/message.test.ts
@@ -212,19 +212,23 @@ describe("handleMessageUpdated", () => {
 
   test("emits api_request log record on success", async () => {
     const { ctx, logger } = makeCtx("proj_test", [], [], true, { team: "platform" })
-    await handleMessageUpdated(makeAssistantMessageUpdated({}), ctx)
+    await handleMessageUpdated(makeAssistantMessageUpdated({ providerID: "amazon-bedrock" }), ctx)
     expect(logger.records).toHaveLength(1)
     expect(logger.records.at(0)!.body).toBe("api_request")
+    expect(logger.records.at(0)!.attributes?.["provider"]).toBe("amazon-bedrock")
+    expect(logger.records.at(0)!.attributes?.["gen_ai.provider.name"]).toBe("aws.bedrock")
     expect(logger.records.at(0)!.attributes?.["team"]).toBe("platform")
   })
 
   test("emits api_error log record on error", async () => {
     const { ctx, logger, pluginLog } = makeCtx()
     await handleMessageUpdated(
-      makeAssistantMessageUpdated({ error: { name: "APIError" } }),
+      makeAssistantMessageUpdated({ providerID: "google-vertex", error: { name: "APIError" } }),
       ctx,
     )
     expect(logger.records.at(0)!.body).toBe("api_error")
+    expect(logger.records.at(0)!.attributes?.["provider"]).toBe("google-vertex")
+    expect(logger.records.at(0)!.attributes?.["gen_ai.provider.name"]).toBe("gcp.vertex_ai")
     expect(logger.records.at(0)!.attributes?.["error"]).toBe("APIError")
     expect(pluginLog.calls.find(c => c.level === "error")?.level).toBe("error")
   })

--- a/tests/handlers/spans.test.ts
+++ b/tests/handlers/spans.test.ts
@@ -356,11 +356,12 @@ describe("message (LLM) spans", () => {
 
   test("startMessageSpan sets OpenInference LLM attributes", () => {
     const { ctx, tracer } = makeCtx()
-    startMessageSpan("ses_1", "msg_1", "user_1", "gpt-4o", "openai", 1000, ctx)
+    startMessageSpan("ses_1", "msg_1", "user_1", "claude-sonnet-4", "amazon-bedrock", 1000, ctx)
     expect(tracer.spans[0]!.attributes[OPENINFERENCE_SPAN_KIND]).toBe(OpenInferenceSpanKind.LLM)
-    expect(tracer.spans[0]!.attributes[LLM_SYSTEM]).toBe("openai")
-    expect(tracer.spans[0]!.attributes[LLM_PROVIDER]).toBe("openai")
-    expect(tracer.spans[0]!.attributes[LLM_MODEL_NAME]).toBe("gpt-4o")
+    expect(tracer.spans[0]!.attributes[LLM_SYSTEM]).toBe("amazon-bedrock")
+    expect(tracer.spans[0]!.attributes[LLM_PROVIDER]).toBe("amazon-bedrock")
+    expect(tracer.spans[0]!.attributes["gen_ai.provider.name"]).toBe("aws.bedrock")
+    expect(tracer.spans[0]!.attributes[LLM_MODEL_NAME]).toBe("claude-sonnet-4")
   })
 
   test("startMessageSpan is a no-op when span already exists for sessionID:messageID", () => {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { errorSummary, setBoundedMap, isMetricEnabled, isTraceEnabled } from "../src/util.ts"
+import { errorSummary, genAiProviderName, setBoundedMap, isMetricEnabled, isTraceEnabled } from "../src/util.ts"
 import { MAX_PENDING } from "../src/types.ts"
 
 describe("errorSummary", () => {
@@ -23,6 +23,26 @@ describe("errorSummary", () => {
 
   test("returns name when data is a primitive", () => {
     expect(errorSummary({ name: "APIError", data: "oops" })).toBe("APIError")
+  })
+})
+
+describe("genAiProviderName", () => {
+  test.each([
+    ["amazon-bedrock", "aws.bedrock"],
+    ["azure", "azure.ai.openai"],
+    ["azure-cognitive-services", "azure.ai.openai"],
+    ["google", "gcp.gemini"],
+    ["google-vertex", "gcp.vertex_ai"],
+    ["google-vertex-anthropic", "gcp.vertex_ai"],
+    ["mistral", "mistral_ai"],
+    ["xai", "x_ai"],
+  ])("maps %s to %s", (providerID, expected) => {
+    expect(genAiProviderName(providerID)).toBe(expected)
+  })
+
+  test("preserves provider IDs without a canonical mapping", () => {
+    expect(genAiProviderName("openrouter")).toBe("openrouter")
+    expect(genAiProviderName("custom-gateway")).toBe("custom-gateway")
   })
 })
 


### PR DESCRIPTION
## Summary

- normalize known opencode provider IDs to canonical `gen_ai.provider.name` values
- preserve unknown and custom provider IDs unchanged
- add the canonical attribute to LLM spans and `api_request`/`api_error` logs without changing existing raw provider attributes
- cover Bedrock, Azure OpenAI, Gemini, Vertex AI, Mistral AI, xAI, and fallback behavior

This also provides a shared `genAiProviderName` helper for GenAI metrics such as the histogram proposed in #102.

## Testing

- `bun run typecheck`
- `bun test` (311 passing)
- `bun run lint`
- `bun run check:jsdoc-coverage`
- `git diff --check`