### PR TITLE
fix(traces): align token counts with OpenInference

### DIFF
--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -70,8 +70,9 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
   const { agentName, agentType } = getSessionAgentMeta(sessionID, ctx)
   const agent = agentName
 
-  const totalTokens = assistant.tokens.input + assistant.tokens.output + assistant.tokens.reasoning
-    + assistant.tokens.cache.read + assistant.tokens.cache.write
+  const promptTokens = assistant.tokens.input + assistant.tokens.cache.read + assistant.tokens.cache.write
+  const completionTokens = assistant.tokens.output + assistant.tokens.reasoning
+  const totalTokens = promptTokens + completionTokens
 
   if (isMetricEnabled("token.usage", ctx)) {
     const { tokenCounter } = ctx.instruments
@@ -124,8 +125,8 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
     msgSpan.setAttributes({
       [AGENT_NAME]: agentName,
       "agent.type": agentType,
-      [LLM_TOKEN_COUNT_PROMPT]: assistant.tokens.input,
-      [LLM_TOKEN_COUNT_COMPLETION]: assistant.tokens.output,
+      [LLM_TOKEN_COUNT_PROMPT]: promptTokens,
+      [LLM_TOKEN_COUNT_COMPLETION]: completionTokens,
       [LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]: assistant.tokens.reasoning,
       [LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]: assistant.tokens.cache.read,
       [LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]: assistant.tokens.cache.write,

--- a/tests/handlers/spans.test.ts
+++ b/tests/handlers/spans.test.ts
@@ -10,6 +10,7 @@ import {
   LLM_TOKEN_COUNT_PROMPT,
   LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
   LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE,
+  LLM_TOKEN_COUNT_TOTAL,
   OpenInferenceSpanKind,
   SemanticConventions,
   SESSION_ID,
@@ -408,11 +409,12 @@ describe("message (LLM) spans", () => {
       ctx,
     )
     const span = tracer.spans[0]!
-    expect(span.attributes[LLM_TOKEN_COUNT_PROMPT]).toBe(200)
-    expect(span.attributes[LLM_TOKEN_COUNT_COMPLETION]).toBe(80)
+    expect(span.attributes[LLM_TOKEN_COUNT_PROMPT]).toBe(235)
+    expect(span.attributes[LLM_TOKEN_COUNT_COMPLETION]).toBe(90)
     expect(span.attributes[LLM_TOKEN_COUNT_COMPLETION_DETAILS_REASONING]).toBe(10)
     expect(span.attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ]).toBe(30)
     expect(span.attributes[LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_WRITE]).toBe(5)
+    expect(span.attributes[LLM_TOKEN_COUNT_TOTAL]).toBe(325)
     expect(span.attributes[AGENT_NAME]).toBe("review")
     expect(span.attributes["agent.type"]).toBe("subagent")
   })


### PR DESCRIPTION
**Summary**
update OpenInference LLM span attributes so `llm.token_count.prompt` includes non-cached input, cache-read, and cache-write tokens
update `llm.token_count.completion` so it includes visible output and reasoning tokens
derive `llm.token_count.total` from the inclusive prompt and completion totals
add regression coverage for prompt, completion, cache details, reasoning details, and total token counts

**Why**
OpenCode stores token usage as non-overlapping categories: ordinary input, cache reads, cache writes, visible output, and reasoning.

OpenInference uses inclusive totals with separate detail attributes. Before this change, the plugin mapped ordinary input directly to `llm.token_count.prompt` and visible output directly to `llm.token_count.completion`. This underreported both attributes whenever caching or reasoning was used, even though `llm.token_count.total` remained numerically correct.

This also causes incorrect token processing in Langfuse. [Langfuse treats OpenTelemetry `llm.token_count.*` attributes as inclusive](https://langfuse.com/docs/observability/features/token-and-cost-tracking) and converts them into mutually exclusive usage buckets by subtracting cache and completion detail tokens from the top-level input and output values. Because the plugin previously emitted already-exclusive values, Langfuse could subtract cache-read, cache-write, or reasoning tokens a second time. This results in underreported or inconsistent usage breakdowns and can produce incorrect inferred costs.

This change aligns the span attributes with OpenInference semantics while preserving the existing non-overlapping `opencode.token.usage` metric categories.

**Validation**
bun run typecheck
bun run lint
bun test
bun run build
git diff --check