### PR TITLE
fix(ci): skip checks for release pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   check:
     name: Typecheck & Test
+    if: ${{ !startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -13,6 +13,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'release-please--branches--') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   title:
     name: Conventional PR title
+    if: ${{ !startsWith(github.head_ref, 'release-please--branches--') }}
     runs-on: ubuntu-latest
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/discord-events.yml
+++ b/.github/workflows/discord-events.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   notify-discord:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && !startsWith(github.head_ref, 'release-please--branches--')) }}
     permissions: {}
     uses: ./.github/workflows/discord-notify.yml
     secrets:


### PR DESCRIPTION
## Summary

- skip CI for Release Please branches
- skip Conventional PR title validation for Release Please branches
- skip Codex review for Release Please branches
- skip duplicate Discord notifications for Release Please PRs

Release Please only changes version and changelog files generated from changes that were already validated in their original pull requests.

GitHub-managed CodeQL default setup remains enabled because it cannot be filtered by head branch from repository workflow YAML.

## Verification

- `bun run typecheck`
- `bun test`
- `bun run lint`
- pre-commit YAML validation