### PR TITLE
feat(handlers): attach trace context to log records

### DIFF
--- a/src/handlers/activity.ts
+++ b/src/handlers/activity.ts
@@ -1,6 +1,6 @@
 import { SeverityNumber } from "@opentelemetry/api-logs"
 import type { EventSessionDiff, EventCommandExecuted } from "@opencode-ai/sdk"
-import { agentAttrs, getSessionAgentMeta, isMetricEnabled, setBoundedMap } from "../util.ts"
+import { agentAttrs, getSessionAgentMeta, isMetricEnabled, resolveSessionTraceContext, setBoundedMap } from "../util.ts"
 import type { HandlerContext } from "../types.ts"
 
 /**
@@ -83,5 +83,6 @@ export function handleCommandExecuted(e: EventCommandExecuted, ctx: HandlerConte
       ...agentAttrs(agentName, agentType),
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(e.properties.sessionID, ctx),
   })
 }

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -177,6 +177,7 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
         duration_ms: duration,
         ...ctx.commonAttrs,
       },
+      context: resolveSessionTraceContext(sessionID, ctx, { runID: assistant.parentID, assistantMessageID: assistant.id }),
     })
     return ctx.log("error", "otel: api_error", {
       sessionID,
@@ -209,6 +210,7 @@ export function handleMessageUpdated(e: EventMessageUpdated, ctx: HandlerContext
       cache_creation_tokens: assistant.tokens.cache.write,
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(sessionID, ctx, { runID: assistant.parentID, assistantMessageID: assistant.id }),
   })
   return ctx.log("info", "otel: api_request", {
     sessionID,
@@ -264,6 +266,7 @@ export function handleMessagePartUpdated(e: EventMessagePartUpdated, ctx: Handle
         prompt_length: subtask.prompt.length,
         ...ctx.commonAttrs,
       },
+      context: resolveSessionTraceContext(subtask.sessionID, ctx),
     })
     return ctx.log("info", "otel: subtask_invoked", {
       sessionID: subtask.sessionID,
@@ -399,6 +402,7 @@ export function handleMessagePartUpdated(e: EventMessagePartUpdated, ctx: Handle
         ...sizeAttr,
         ...ctx.commonAttrs,
       },
+      context: resolveSessionTraceContext(toolPart.sessionID, ctx, { assistantMessageID: toolPart.messageID }),
     })
     ctx.log("debug", "otel: tool.duration histogram recorded", {
       sessionID: toolPart.sessionID,

--- a/src/handlers/permission.ts
+++ b/src/handlers/permission.ts
@@ -1,6 +1,6 @@
 import { SeverityNumber } from "@opentelemetry/api-logs"
 import type { EventPermissionUpdated, EventPermissionReplied } from "@opencode-ai/sdk"
-import { agentAttrs, getSessionAgentMeta, setBoundedMap } from "../util.ts"
+import { agentAttrs, getSessionAgentMeta, resolveSessionTraceContext, setBoundedMap } from "../util.ts"
 import type { HandlerContext } from "../types.ts"
 
 /** Stores a pending permission prompt in the context map for later correlation with its reply. */
@@ -38,5 +38,6 @@ export function handlePermissionReplied(e: EventPermissionReplied, ctx: HandlerC
       ...agentAttrs(agentName, agentType),
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(sessionID, ctx),
   })
 }

--- a/src/handlers/session.ts
+++ b/src/handlers/session.ts
@@ -125,6 +125,7 @@ export function handleSessionCreated(e: EventSessionCreated, ctx: HandlerContext
       ...agentAttrs("unknown", agentType),
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(sessionID, ctx),
   })
   return ctx.log("info", "otel: session.created", { sessionID, createdAt, isSubagent })
 }
@@ -230,6 +231,7 @@ export function handleSessionIdle(e: EventSessionIdle, ctx: HandlerContext) {
       ...agentAttrs(agentName, agentType),
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(sessionID, ctx),
   })
   ctx.log("debug", "otel: session.idle", {
     sessionID,
@@ -284,6 +286,7 @@ export function handleSessionError(e: EventSessionError, ctx: HandlerContext) {
       ...agentAttrs(agentName, agentType),
       ...ctx.commonAttrs,
     },
+    context: resolveSessionTraceContext(sessionID, ctx),
   })
   ctx.log("error", "otel: session.error", { sessionID, error })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { handleMessageUpdated, handleMessagePartUpdated, startMessageSpan } from
 import { handlePermissionUpdated, handlePermissionReplied } from "./handlers/permission.ts"
 import { handleSessionDiff, handleCommandExecuted } from "./handlers/activity.ts"
 import { handleChatHeaders } from "./handlers/chat-headers.ts"
-import { agentAttrs, getSessionAgentMeta, setBoundedMap } from "./util.ts"
+import { agentAttrs, getSessionAgentMeta, resolveSessionTraceContext, setBoundedMap } from "./util.ts"
 import type { SessionTotals } from "./types.ts"
 
 const PLUGIN_VERSION: string = (pkg as { version?: string }).version ?? "unknown"
@@ -290,6 +290,7 @@ export const OtelPlugin: Plugin = async ({ project, client, directory, worktree 
             : "unknown",
           ...commonAttrs,
         },
+        context: resolveSessionTraceContext(input.sessionID, ctx),
       })
     }),
 


### PR DESCRIPTION
## Description

Log records emitted by the plugin carry no trace context, so they can't be correlated with the spans from the same session. 

This makes it difficult to have traces to logs cross signal correlation.

This change attaches a context to all ten `emitLog` call sites, reusing the existing `resolveSessionTraceContext()` / `resolveRunTraceContext()` helpers from `util.ts`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (dependency updates, etc.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] My code follows the style guidelines of this project
- [x] `bun run lint` passes with no errors
- [x] `bun run check:jsdoc-coverage` passes with no errors
- [x] `bun run typecheck` passes with no errors
- [x] `bun test` passes with no errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
